### PR TITLE
fix failing tests with the addition of Faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,10 @@ group :development, :test do
   gem 'factory_bot_rails'
 end
 
+group :test do
+  gem 'faker'
+end
+
 group :development do
   gem 'annotate'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
@@ -286,6 +288,7 @@ DEPENDENCIES
   byebug
   devise
   factory_bot_rails
+  faker
   font-awesome-rails
   guard-rspec
   jbuilder (~> 2.7)

--- a/spec/factories/listings.rb
+++ b/spec/factories/listings.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
     factory :ask, class: "Ask" do
       type { "Ask" }
     end
+
+    trait :with_contact_info do
+      name { Faker::Name.name }
+      email { Faker::Internet.email}
+      phone { Faker::PhoneNumber.phone_number }
+    end
   end
 end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe "/listings", type: :request do
   let(:valid_attributes) {{
     location_attributes: {zip: "12345"},
-    tags: ["", "cash"]
+    tags: ["", "cash"],
+    name: Faker::Name.name,
+    email: Faker::Internet.email,
+    phone: Faker::PhoneNumber.phone_number
   }}
 
   let(:invalid_attributes) {{
@@ -83,11 +86,12 @@ RSpec.describe "/listings", type: :request do
   end
 
   describe "PATCH /update" do
-    let(:listing) { create(:listing) }
+    let(:listing) { create(:listing, :with_contact_info) }
 
     context "with valid parameters" do
+      let(:new_street_address) { Faker::Address.street_address }
       let(:new_attributes) {{
-        location_attributes: {street_address: 'changed'},
+        location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
       }}
 
       before do
@@ -95,7 +99,7 @@ RSpec.describe "/listings", type: :request do
       end
 
       it "updates the requested listing" do
-        expect(listing.reload.location.street_address).to eq('changed')
+        expect(listing.reload.location.street_address).to eq(new_street_address)
       end
 
       it "redirects to the listing" do


### PR DESCRIPTION
I added Faker and fixed the tests that `bin/rspec` said were failing. I'm okay with editing this change to not use faker, if anyone prefers that.

Here are some decisions this commit goes along with that we might change soon based on new requirements:
- we're not accepting zip+4 format yet
- we're not accepting Canadian postal codes yet
- listings currently must have both an email and a phone number