### PR TITLE
Add Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
             set -euxo pipefail
             bundle config path .bundle
             bin/rails db:setup
-            bin/rspec
+            bin/rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
 
 jobs:
   bundle:
@@ -72,6 +72,8 @@ jobs:
     steps:
       - checkout
       - test_suite
+      - store_test_results:
+          path: ~/rspec
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,85 @@
+docker_image: &docker_image
+  image: circleci/ruby:2.7.0-node
+
+version: 2.1
+commands:
+  bundle_install:
+    description: "Performs the bundler installation, relying on the CircleCI cache for performance"
+    steps:
+      - restore_cache:
+          keys:
+            - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: "Bundle Install"
+          command: bin/bundle install --path=.bundle
+      - save_cache:
+          key: bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - .bundle
+  yarn_install:
+    description: "Performs node module installation with yarn, relying on the CircleCI cache for performance"
+    steps:
+      - restore_cache:
+          keys:
+            - yarn-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: "Yarn Install"
+          command: bin/yarn install
+      - save_cache:
+          key: yarn-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+  test_suite:
+    description: "Run the test suite"
+    steps:
+      - restore_cache:
+          keys:
+            - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
+      - restore_cache:
+          keys:
+            - yarn-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: "Run the Test Suite"
+          command: |
+            set -euxo pipefail
+            bundle config path .bundle
+            bin/rails db:setup
+            bin/rspec
+
+jobs:
+  bundle:
+    docker:
+      - <<: *docker_image
+    steps:
+      - checkout
+      - bundle_install
+  yarn:
+    docker:
+      - <<: *docker_image
+    steps:
+      - checkout
+      - yarn_install
+  test:
+    docker:
+      - <<: *docker_image
+        environment:
+          RAILS_ENV: test
+      - image: circleci/postgres:latest
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: mutualaid_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+    steps:
+      - checkout
+      - test_suite
+
+workflows:
+  version: 2.1
+  mutual_aid:
+    jobs:
+      - bundle
+      - yarn
+      - test:
+          requires:
+            - bundle
+            - yarn

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+# DB hostname required for CircleCI. Feel free to override it in .env.test.local
+POSTGRES_HOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ yarn-debug.log*
 .yarn-integrity
 
 /spec/examples.txt
+
+# Ignore the recommended dontenv ingored files
+.env.development.local
+.env.test.local
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -23,11 +23,6 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-gem "font-awesome-rails"
-gem 'devise'
-gem 'reform-rails'
-gem 'simple_form'
-
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
@@ -35,14 +30,18 @@ gem 'simple_form'
 gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'acts-as-taggable-array-on'
+gem 'devise'
+gem "font-awesome-rails"
+gem 'reform-rails'
+gem 'simple_form'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry'
   gem 'binding_of_caller'
-  gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'pry'
+  gem 'rspec-rails'
 end
 
 group :test do
@@ -51,14 +50,14 @@ end
 
 group :development do
   gem 'annotate'
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
+  gem 'guard-rspec', require: false
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'guard-rspec', require: false
+  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
+  gem 'web-console', '>= 3.3.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,10 @@ group :development, :test do
   gem 'factory_bot_rails'
 end
 
+group :test do
+  gem 'faker'
+end
+
 group :development do
   gem 'annotate'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ ruby '2.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
+
+# This should after rails but before any gems that might require it
+gem 'dotenv-rails', require: 'dotenv/rails-now'
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ end
 
 group :test do
   gem 'faker'
+
+  # an XML formatter is required for fancier CircleCI results
+  gem 'rspec_junit_formatter'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     ruby_dep (1.5.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -304,6 +306,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.2)
   reform-rails
   rspec-rails
+  rspec_junit_formatter
   sass-rails (>= 6)
   simple_form
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
@@ -286,6 +288,7 @@ DEPENDENCIES
   byebug
   devise
   factory_bot_rails
+  faker
   font-awesome-rails
   guard-rspec
   jbuilder (~> 2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,10 @@ GEM
       declarative-option (< 0.2.0)
       representable (>= 2.4.0, <= 3.1.0)
       uber (< 0.2.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     factory_bot (5.1.2)
       activesupport (>= 4.2.0)
@@ -287,6 +291,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   devise
+  dotenv-rails
   factory_bot_rails
   faker
   font-awesome-rails

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,6 +58,11 @@ development:
 test:
   <<: *default
   database: mutualaid_test
+  # Our CircleCI setup uses containers where the domain socket won't work
+  # So we have to specify a host and port instead
+  <% if ENV['POSTGRES_HOST'] %>
+  host: <%= ENV['POSTGRES_HOST'] %>
+  <% end %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Required here for CircleCI
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/spec/factories/listings.rb
+++ b/spec/factories/listings.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
     factory :ask, class: "Ask" do
       type { "Ask" }
     end
+
+    trait :with_contact_info do
+      name { Faker::Name.name }
+      email { Faker::Internet.email}
+      phone { Faker::PhoneNumber.phone_number }
+    end
   end
 end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe "/listings", type: :request do
   let(:valid_attributes) {{
     location_attributes: {zip: "12345"},
-    tags: ["", "cash"]
+    tags: ["", "cash"],
+    name: Faker::Name.name,
+    email: Faker::Internet.email,
+    phone: Faker::PhoneNumber.phone_number
   }}
 
   let(:invalid_attributes) {{
@@ -83,11 +86,12 @@ RSpec.describe "/listings", type: :request do
   end
 
   describe "PATCH /update" do
-    let(:listing) { create(:listing) }
+    let(:listing) { create(:listing, :with_contact_info) }
 
     context "with valid parameters" do
+      let(:new_street_address) { Faker::Address.street_address }
       let(:new_attributes) {{
-        location_attributes: {street_address: 'changed'},
+        location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
       }}
 
       before do
@@ -95,7 +99,7 @@ RSpec.describe "/listings", type: :request do
       end
 
       it "updates the requested listing" do
-        expect(listing.reload.location.street_address).to eq('changed')
+        expect(listing.reload.location.street_address).to eq(new_street_address)
       end
 
       it "redirects to the listing" do


### PR DESCRIPTION
Here's a Circle CI config with relevant config changes. Important notes:
- I added the `dotenv` gem because that will help with keeping testing, development, and deployment variables consistent. It may also be helpful when it comes to welcoming new people with unusual computer configurations who want to contribute
- This includes the changes in https://github.com/maebeale/mutual-aid/pull/31 because otherwise the tests would fail and because rebasing without those test fixes and then rebasing again after that's merged in would be annoying and a little silly. That said, I put the tests in a separate PR to make it easy for everyone to look at them separately. If you want to review code changes, you should probably review https://github.com/maebeale/mutual-aid/pull/31 first

Otherwise, it's not too unusual as CircleCI configs go

Once this is merged in, using the default options on the CircleCI side to tell it to run this config should work just fine