### PR TITLE
move listings page into vue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'binding_of_caller'
   gem 'factory_bot_rails'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,9 @@ GEM
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -301,6 +304,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
+  pry-byebug
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
   reform-rails

--- a/app/assets/stylesheets/listings.scss
+++ b/app/assets/stylesheets/listings.scss
@@ -27,3 +27,13 @@
     display: none;
   }
 }
+
+.listing-body table {
+  border-collapse: collapse;
+  tr td, tr th {
+    border-width: 1px;
+    border-color: black;
+    border-style: solid;
+    padding: 1em;
+  }
+}

--- a/app/javascript/components/PublicListings.vue
+++ b/app/javascript/components/PublicListings.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <div class='listing-body'>
+      <table>
+        <tr>
+          <th>Created At</th>
+          <th>Name</th>
+          <th>Location</th>
+          <th>Details</th>
+        </tr>
+        <tr v-for="listing in listings" :key="listing.id">
+          <td>{{ listing.created_at }}</td>
+          <td>{{ listing.name }}</td>
+          <td></td>
+          <td></td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    let data = {}
+    data.errors = ["Listings not yet fetched"]
+    data.listings = []
+    data.urls = {}
+    return data
+  },
+  created() {
+    var _this = this
+    fetch('/listings.json')
+      .then( result => result.json())
+      .then( json => {
+        _this.listings = json.listings
+        _this.urls = json.urls
+        _this.errors = []
+      })
+      .catch( error => {
+        _this.errors.push(error)
+      })
+  }
+}
+</script>

--- a/app/javascript/components/index.js
+++ b/app/javascript/components/index.js
@@ -1,9 +1,11 @@
 import HelloWorld from './HelloWorld'
 import Orientation from './Orientation'
 import AboutSection from './AboutSection'
+import PublicListings from './PublicListings'
 
 export {
   HelloWorld,
   Orientation,
   AboutSection,
+  PublicListings
 }

--- a/app/javascript/entry_points/index.js
+++ b/app/javascript/entry_points/index.js
@@ -1,7 +1,9 @@
 import hello from './hello'
 import orientation from './orientation'
+import publicListings from './publicListings'
 
 export {
   hello,
   orientation,
+  publicListings
 }

--- a/app/javascript/entry_points/publicListings.js
+++ b/app/javascript/entry_points/publicListings.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import {PublicListings} from '../components'
+
+export default function(el) {
+  new Vue({
+    el,
+    render(h) {
+      return h(PublicListings)
+    }
+  })
+}

--- a/app/views/listings/_listing.json.jbuilder
+++ b/app/views/listings/_listing.json.jbuilder
@@ -1,2 +1,4 @@
-json.extract! listing, :id, :type, :created_at, :updated_at
+json.extract! listing, :id, :name, :type
+json.created_at "#{listing.created_at.to_formatted_s(:long)} #{listing.created_at.zone}"
+json.updated_at "#{listing.updated_at.to_formatted_s(:long)} #{listing.updated_at.zone}"
 json.url listing_url(listing, format: :json)

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -1,27 +1,11 @@
 <div class="section">
-  <h1 class="title">Listings</h1>
-
-  <table>
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <% @listings.each do |listing| %>
-        <tr>
-          <td><%= listing.type %></td>
-          <td><%= link_to 'Show', listing %></td>
-          <td><%= link_to 'Edit', edit_listing_path(listing) %></td>
-          <td><%= link_to 'Destroy', listing, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-
-  <br>
-
-  <%= link_to 'New Listing', new_listing_path %>
+  <div id="public-listings">
+  </div>
 </div>
+
+<script>
+ document.addEventListener('DOMContentLoaded', () => {
+    EntryPoints.publicListings('#public-listings')
+  })
+
+</script>

--- a/app/views/listings/index.json.jbuilder
+++ b/app/views/listings/index.json.jbuilder
@@ -1,1 +1,6 @@
-json.array! @listings, partial: "listings/listing", as: :listing
+json.listings do
+    json.array! @listings, partial: "listings/listing", as: :listing
+end
+json.urls do
+    json.new_listing new_listing_path
+end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -15,11 +15,24 @@ RSpec.describe "/listings", type: :request do
 
   before { sign_in create(:user) }
 
-  pending "GET /index" do
+  describe "GET /index" do
     it "renders a successful response" do
-      Listing.create! valid_attributes
+      create(:listing)
       get listings_url
       expect(response).to be_successful
+    end
+
+    it "can respond with json" do
+      expected_listing = create(:listing)
+      headers = { "ACCEPT" => "application/json" }
+      get listings_url, headers: headers
+      json_response = JSON.parse(response.body)
+      comparison_keys = %w[id type created_at updated_at type]
+      expect(json_response['listings'].length).to eq 1
+      listing_result = json_response['listings'][0]
+      expected_time_format = "#{expected_listing.created_at.to_formatted_s(:long)} #{expected_listing.created_at.zone}"
+      expect(listing_result['created_at']).to eq expected_time_format
+      expect(listing_result['name']).to eq expected_listing.name
     end
   end
 


### PR DESCRIPTION
## Description

This is an initial go at putting the listings page in Vue. I forget who recommend it this past weekend, but the gist is that the listing page makes more sense as a first place to get Vue up and working than the listing form for creating & editing listings. This is my skeleton for that page. Some things are missing, as might be obvious in the screenshot below. I'll also make a note of them in comments further down

## Screenshots

<img width="1105" alt="Screen Shot 2020-04-14 at 12 00 51 PM" src="https://user-images.githubusercontent.com/3620291/79246761-9cffa980-7e47-11ea-980e-e3010c8d050b.png">
<img width="487" alt="Screen Shot 2020-04-14 at 12 00 57 PM" src="https://user-images.githubusercontent.com/3620291/79246766-9f620380-7e47-11ea-80db-ccebb6d47427.png">

