### PR TITLE
[REFERENCE] playing around w fields for ask vs offer forms

### DIFF
--- a/app/views/listings/_ask_form.html.erb
+++ b/app/views/listings/_ask_form.html.erb
@@ -1,0 +1,52 @@
+<% ask ||= listing %>
+<div class=''>
+  <%= form_with(model: listing, local: true, class: 'listing-form') do |form| %>
+    <% if listing.errors.any? %>
+      <div id="error_explanation">
+        <h2 class="subtitle"><%= pluralize(listing.errors.count, "error") %> prohibited this listing from being saved:</h2>
+        <ul>
+          <% listing.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <hr>
+    <%= render "listings/form_tags_section", form: form %>
+    <hr>
+    <p class="lead">
+      Leave blank any fields you'd like, except those
+      marked with an asterisk (<span style="color: orange">*</span>)
+    </p>
+    <hr>
+    <%= render "listings/form_contact_info", form: form %>
+    <hr>
+
+    <p class="lead">
+      Would you like to log in and check on the status of your asks?
+    </p>
+    <div class="field is-grouped">
+      <div class="field required">
+        <div class="label">Create login?</div>
+        <%= form.check_box(class: "", style: "display: none") %>
+        <small class="form-text text-muted">Log in</small>
+      </div>
+      <div class="field required">
+        <%= form.label :login_name, :class=>"label" %>
+        <%= form.text_field :name, class: "input" %>
+        <small class="form-text text-muted">Your name or a username</small>
+      </div>
+    </div>
+
+    <hr>
+    <p class="lead">
+      We will do our best to help. We're all in this together.
+    </p>
+    <hr>
+
+    <div class="actions">
+      <%= form.submit 'Submit', class: "button is-primary mt-1" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/listings/_form_contact_info.html.erb
+++ b/app/views/listings/_form_contact_info.html.erb
@@ -1,0 +1,60 @@
+<p class="lead">How may we contact you?</p>
+
+<div class="field is-grouped">
+  <div class="field required">
+    <%= form.label :email, :class=>"label" %>
+    <%= form.email_field :email, class: "input" %>
+    <small class="form-text text-muted">Email or a phone required</small>
+  </div>
+  <div class="field required">
+    <%= form.label :phone, :class=>"label"%>
+    <%= form.phone_field :phone, class: "input" %>
+  </div>
+  <div class="field required">
+    <div class="label">Preferred contact method?<span style="color: orange">*</span></div>
+    <div class="input">Call,Text,Email, No preference</div>
+  </div>
+</div>
+
+<div class="field is-grouped">
+  <div class="field required">
+    <div class="label">Availability</div>
+    <div class="input">AM/PM/EVE/WEEKDAY/WKND</div>
+  </div>
+  <div class="field required">
+    <div class="label">Neighbors can view my profile</div>
+    <%= form.check_box(class: "", style: "display: none") %>
+  </div>
+  <div class="field required">
+    <div class="label">Neighbors can view my asks and offers</div>
+    <%= form.check_box(class: "", style: "display: none") %>
+  </div>
+  <div class="field required">
+    <div class="label">Neighbors can contact me directly</div>
+    <%= form.check_box(class: "", style: "display: none") %>
+  </div>
+</div>
+
+<%= form.fields_for :location do |location_form| %>
+  <div class="field is-grouped">
+    <div class="field required">
+      <%= location_form.label :location, :class=>"label"%>
+      <%= location_form.text_field :city, list: "cities", class: "input",
+                                   placeholder: "Select or type another in..." %>
+      <datalist id="cities">
+        <%= LocationForm::CITIES.each do |city| %>
+          <option value="<%= city %>"></option>
+        <% end %>
+      </datalist>
+    </div>
+    <div class="field">
+      <%= location_form.label :zip, :class=>"label"%>
+      <%= location_form.text_field :zip, class: "input" %>
+    </div>
+    <div class="field">
+      <%= location_form.label :street_address, :class=>"label" %>
+      <%= location_form.text_field :street_address, class: "input" %>
+      <small class="form-text text-muted">Address or crosstreet, eg "1200 Block, 1st St"</small>
+    </div>
+  </div>
+<% end %>

--- a/app/views/listings/_form_tags_section.html.erb
+++ b/app/views/listings/_form_tags_section.html.erb
@@ -1,0 +1,26 @@
+<div>
+  <%= form.label :tags, class: "label" %>
+  <%= form.collection_check_boxes(:tags, ListingForm.all_tags, :itself, :itself) do |b| %>
+    <%# Derived from https://bootsnipp.com/snippets/M2bda %>
+    <div class="field is-grouped mb-0">
+      <%# FIXME: is-hidden class not working? Buttons also need more work %>
+      <%= b.check_box(class: "is-hidden", style: "display: none") %>
+      <%= b.label(class: "button is-small is-outlined") do %>
+        <span>&#10003;</span> <!-- made visible via css when checked -->
+        <span> </span>
+      <% end %>
+      <%= b.label(class: "button is-small is-outlined") do %>
+        <%= b.value.capitalize %>
+      <% end %>
+      <%= b.label(class: "button is-small is-outlined") do %>
+        Urgency
+      <% end %>
+      <%= b.label(class: "button is-small is-outlined") do %>
+        Needed by date
+      <% end %>
+      <%= b.label(class: "button is-small is-outlined") do %>
+        Notes
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/listings/_offer_form.html.erb
+++ b/app/views/listings/_offer_form.html.erb
@@ -1,0 +1,45 @@
+<% offer ||= listing %>
+<div class='section'>
+  <%= form_with(model: listing, local: true, class: 'listing-form') do |form| %>
+    <% if listing.errors.any? %>
+      <div id="error_explanation">
+        <h2 class="subtitle"><%= pluralize(listing.errors.count, "error") %> prohibited this listing from being saved:</h2>
+        <ul>
+          <% listing.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <p class="lead">
+      Information you enter below will be shared publicly unless you opt out.
+      Leave blank any fields you prefer not to to fill out, except those
+      marked mith an asterisk (<span style="color: orange">*</span>)
+    </p>
+
+    <hr>
+
+    <div class="field required">
+      <%= form.label :name, :class=>"label"%>
+      <%= form.text_field :name, class: "input", required: true %>
+      <small class="form-text text-muted">We'll create an account for you</small>
+    </div>
+
+    <hr>
+    <%= render "listings/form_contact_info", form: form %>
+    <hr>
+    <%= render "listings/form_tags_section", form: form %>
+    <hr>
+
+    <div class="field required">
+      <%= form.label :skills, :class=>"label"%>
+      <%= form.text_field :skills, class: "input", required: true %>
+      <small class="form-text text-muted">List any skills you have</small>
+    </div>
+
+    <div class="actions">
+      <%= form.submit 'Submit', class: "button is-primary mt-1" %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
@exbinary these files might be a good starter reference?

for the checkbox section on Asks, maybe it could have an accordion that opens if you select it, and then you get the other fields: Urgency dropdown, Date Requested, Notes, [is_ongoing] boolean.

for checkbox section on Offers,  instead of Date Requested or Ugency, maybe two subfields: 
* something about # times per week (or # times total?)
* Notes 
?

Re order of fields:
* For Asks, we prob should put our offerings as first thing they see, rather than asking contact info asap, so the order was swapped for Ask vs Offer (hence the shared partials)

Still lots of nuances to think about here re creating accounts and letting people have some preferences re what will/will not be public. 

The fields in these draft forms aren't connected to the models or current db -- just was spitballing to talk w folks.

We'll also need to create Locations w the addy data (that's connected to a SystemLocation ?)

<img width="859" alt="Screen Shot 2020-04-17 at 9 41 32 AM" src="https://user-images.githubusercontent.com/7607813/79642959-6c34b280-816e-11ea-8a21-fc12ddee5cf9.png">
<img width="794" alt="Screen Shot 2020-04-17 at 9 41 49 AM" src="https://user-images.githubusercontent.com/7607813/79642962-6f2fa300-816e-11ea-8c77-59f6ad08be6b.png">
<img width="870" alt="Screen Shot 2020-04-17 at 9 42 02 AM" src="https://user-images.githubusercontent.com/7607813/79642963-722a9380-816e-11ea-9ee8-73b87e2bddc4.png">
<img width="835" alt="Screen Shot 2020-04-17 at 9 42 08 AM" src="https://user-images.githubusercontent.com/7607813/79642966-75be1a80-816e-11ea-942a-b87b41f8acda.png">
