### PR TITLE
Set viewport meta-tag since our site is responsive

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
   </head>

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
   </head>


### PR DESCRIPTION
Seems obvious now, but blew a couple hours trying to figure out why things that should have been responsive weren't behaving that way!

[Reference](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag)