### PR TITLE
Pin Bulma version to Buefy, scope overrides for SimpleForm

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,6 @@
 @import 'font-awesome';
 
-@import './bulma_customization';
-@import 'bulma/bulma';
-
-@import 'buefy/dist/buefy.css';
+@import './bulma_and_buefy';
 
 @import './custom_spacing_helpers';
 @import './simple_form_customization';
@@ -13,5 +10,3 @@
 .text-center {
   text-align: center;
 }
-
-

--- a/app/assets/stylesheets/bulma_and_buefy.scss
+++ b/app/assets/stylesheets/bulma_and_buefy.scss
@@ -1,0 +1,9 @@
+// Import Bulma's core if needed for customizations
+// @import "bulma/sass/utilities/_all";
+
+// Our customizations
+$input-placeholder-color: hsl(0, 0%, 86%); //has-text-grey-lighter
+
+
+@import "bulma/bulma";
+@import "buefy/src/scss/buefy";

--- a/app/assets/stylesheets/bulma_customization.scss
+++ b/app/assets/stylesheets/bulma_customization.scss
@@ -1,1 +1,0 @@
-$input-placeholder-color: hsl(0, 0%, 86%); //has-text-grey-lighter

--- a/app/assets/stylesheets/simple_form_customization.scss
+++ b/app/assets/stylesheets/simple_form_customization.scss
@@ -1,14 +1,17 @@
 //# hacks for simple-form + bulma
 
-.is-inline-flex {
-  display: inline-flex;
-}
-.select {
-  vertical-align: baseline;
-}
-.form-actions {
-  padding-top: 3em;
-}
-.select:not(.is-multiple):not(.is-loading)::after, .navbar-link:not(.is-arrowless)::after {
-  margin-top: 2.5em;
+.simple-form {
+  .is-inline-flex {
+    display: inline-flex;
+  }
+  .select {
+    vertical-align: baseline;
+  }
+  .form-actions {
+    padding-top: 3em;
+  }
+
+  .select:not(.is-multiple):not(.is-loading)::after, .navbar-link:not(.is-arrowless)::after {
+    margin-top: 2.5em;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@rails/webpacker": "4.2.2",
     "babel-loader": "^8.1.0",
     "buefy": "^0.8.17",
-    "bulma": "^0.8.1",
     "css-loader": "^3.5.2",
     "style-loader": "^1.1.4",
     "vue": "^2.6.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,11 +1643,6 @@ bulma@0.7.5:
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.5.tgz#35066c37f82c088b68f94450be758fc00a967208"
   integrity sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw==
 
-bulma@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.8.1.tgz#a5feacb703b73a87fdeae4f0d12317d62fc1d301"
-  integrity sha512-Afi2zv4DKmNSYfmx55V+Mtnt8+WfR8Rs65kWArmzEuWP7vNr7dSAEDI+ORZlgOR1gueNZwpKaPdUi4ZiTNwgPA==
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"


### PR DESCRIPTION
Two tweaks became apparent as i started to use Buefy:
1. Its probably best for us to use the Bulma version that is specified in the Buefy dependencies so that we are using the version they test against. I haven't run into any incompatibilities yet, but figured this would be safer until there's a reason to pull in the latest Bulma.
2. The css overrides for SimpleForm+Bulma were defined globally and broke Buefy. Since they should only be needed within a SimpleForm, i've scoped them accordingly. Note: i didn't test this because i'm not familiar with the specific tweaks. LMK if this works, @maebeale .