### PR TITLE
Several improvements to layout code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
-gem 'bulma'
-gem 'font-awesome-rails'
 gem 'devise'
 gem 'reform-rails'
 gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,6 @@ GEM
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
-    bulma (0.1.0)
     byebug (11.1.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -105,8 +104,6 @@ GEM
     faker (2.11.0)
       i18n (>= 1.6, < 2)
     ffi (1.12.2)
-    font-awesome-rails (4.7.0.5)
-      railties (>= 3.2, < 6.1)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -292,13 +289,11 @@ DEPENDENCIES
   annotate
   binding_of_caller
   bootsnap (>= 1.4.2)
-  bulma
   byebug
   devise
   dotenv-rails
   factory_bot_rails
   faker
-  font-awesome-rails
   guard-rspec
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,22 +1,14 @@
-@import 'font-awesome';
-
+@import './font_awesome';
 @import './bulma_and_buefy';
 
 @import './custom_spacing_helpers';
 @import './simple_form_customization';
+
 @import './listings';  // TODO: remove this once listings/new is refactored
 
  // TODO: use has-text-centered instead
 .text-center {
   text-align: center;
-}
-
-.main-footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 60px;
-  line-height: 60px;
 }
 
 .section-detail {

--- a/app/assets/stylesheets/font_awesome.scss
+++ b/app/assets/stylesheets/font_awesome.scss
@@ -1,0 +1,7 @@
+// https://stackoverflow.com/a/58087255
+
+$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
+
+@import '@fortawesome/fontawesome-free/scss/fontawesome';
+@import '@fortawesome/fontawesome-free/scss/solid';
+@import '@fortawesome/fontawesome-free/scss/regular';

--- a/app/javascript/components/DeleteButton.vue
+++ b/app/javascript/components/DeleteButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <form :action="action" method="post">
+    <input type="hidden" name="_method" value="delete" />
+    <input type="hidden" name="authenticity_token" :value="authenticityToken" />
+    <button type="submit" class="button is-outlined">
+      <slot />
+    </button>
+  </form>
+</template>
+
+<script>
+export default {
+  props: {
+    action: String,
+  },
+  computed: {
+    authenticityToken() {
+      return document.querySelector('meta[name="csrf-token"]').content
+    },
+  },
+}
+</script>

--- a/app/javascript/components/NavBar.vue
+++ b/app/javascript/components/NavBar.vue
@@ -1,0 +1,48 @@
+<template>
+  <b-navbar fixed-top transparent shadow>
+    <template slot="brand">
+      <b-navbar-item href="/">
+        <img :src="$options.logo" alt="festi logo" height="300px">
+      </b-navbar-item>
+    </template>
+    <template slot="start">
+      <b-navbar-item href="/about">About</b-navbar-item>
+      <b-navbar-item href="/share">Share</b-navbar-item>
+      <b-navbar-item href="/community_resources_list">Community Resources</b-navbar-item>
+      <b-navbar-item href="/news">Announcements</b-navbar-item>
+    </template>
+    <template slot="end" v-if="loggedIn">
+      <b-navbar-item href="/users/edit">Account</b-navbar-item>
+      <b-navbar-item href="/admin">Admin</b-navbar-item>
+      <b-navbar-item tag="div">
+        <form action="/users/sign_out" method="post">
+          <input type="hidden" name="_method" value="delete" />
+          <input type="hidden" name="authenticity_token" :value="authenticityToken" />
+          <button type="submit" class="button is-outlined">Logout</button>
+        </form>
+      </b-navbar-item>
+    </template>
+    <template slot="end" v-else>
+      <b-navbar-item tag="div">
+        <a href="/users/sign_in" class="button is-outlined">Login</a>
+      </b-navbar-item>
+    </template>
+  </b-navbar>
+</template>
+
+<script>
+import logo from 'images/logo.png'
+
+export default {
+  logo: logo,
+  props: {
+    loggedIn: Boolean,
+  },
+  computed: {
+    authenticityToken() {
+      return document.querySelector('meta[name="csrf-token"]').content
+    },
+  },
+}
+</script>
+

--- a/app/javascript/components/NavBar.vue
+++ b/app/javascript/components/NavBar.vue
@@ -5,21 +5,19 @@
         <img :src="$options.logo" alt="festi logo" height="300px">
       </b-navbar-item>
     </template>
+
     <template slot="start">
       <b-navbar-item href="/about">About</b-navbar-item>
       <b-navbar-item href="/share">Share</b-navbar-item>
       <b-navbar-item href="/community_resources_list">Community Resources</b-navbar-item>
       <b-navbar-item href="/news">Announcements</b-navbar-item>
     </template>
+
     <template slot="end" v-if="loggedIn">
       <b-navbar-item href="/users/edit">Account</b-navbar-item>
       <b-navbar-item href="/admin">Admin</b-navbar-item>
       <b-navbar-item tag="div">
-        <form action="/users/sign_out" method="post">
-          <input type="hidden" name="_method" value="delete" />
-          <input type="hidden" name="authenticity_token" :value="authenticityToken" />
-          <button type="submit" class="button is-outlined">Logout</button>
-        </form>
+        <DeleteButton action="users/sign_out">Logout</DeleteButton>
       </b-navbar-item>
     </template>
     <template slot="end" v-else>
@@ -32,17 +30,16 @@
 
 <script>
 import logo from 'images/logo.png'
+import DeleteButton from 'components/DeleteButton'
 
 export default {
-  logo: logo,
   props: {
     loggedIn: Boolean,
   },
-  computed: {
-    authenticityToken() {
-      return document.querySelector('meta[name="csrf-token"]').content
-    },
+  components: {
+    DeleteButton,
   },
+  logo: logo,
 }
 </script>
 

--- a/app/javascript/components/Notice.vue
+++ b/app/javascript/components/Notice.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- TODO: Remove this if we decide to use the Snackbar version -->
   <!-- Note: without a title, buefy generates a headless message, which is not closable -->
   <b-message
     :type="`is-${type}`"

--- a/app/javascript/components/Notice.vue
+++ b/app/javascript/components/Notice.vue
@@ -1,0 +1,15 @@
+<template>
+  <!-- note: buefy requires a title to generate a closable message -->
+  <b-message title=" " :type="`is-${type}`" aria-close-label="Close message">
+    {{ message }}
+  </b-message>
+</template>
+
+<script>
+export default {
+  props: {
+    message: String,
+    type: String,
+  },
+}
+</script>

--- a/app/javascript/components/Notice.vue
+++ b/app/javascript/components/Notice.vue
@@ -1,6 +1,11 @@
 <template>
-  <!-- note: buefy requires a title to generate a closable message -->
-  <b-message title=" " :type="`is-${type}`" aria-close-label="Close message">
+  <!-- Note: without a title, buefy generates a headless message, which is not closable -->
+  <b-message
+    :type="`is-${type}`"
+    title=" "
+    aria-close-label="Close message"
+    has-icon
+  >
     {{ message }}
   </b-message>
 </template>

--- a/app/javascript/entry_points/index.js
+++ b/app/javascript/entry_points/index.js
@@ -1,9 +1,11 @@
 import hello from './hello'
+import navBar from './navBar'
 import orientation from './orientation'
 import publicListings from './publicListings'
 
 export {
   hello,
+  navBar,
   orientation,
   publicListings
 }

--- a/app/javascript/entry_points/index.js
+++ b/app/javascript/entry_points/index.js
@@ -1,11 +1,13 @@
 import hello from './hello'
 import navBar from './navBar'
+import notice from './notice'
 import orientation from './orientation'
 import publicListings from './publicListings'
 
 export {
   hello,
   navBar,
+  notice,
   orientation,
   publicListings
 }

--- a/app/javascript/entry_points/navBar.js
+++ b/app/javascript/entry_points/navBar.js
@@ -1,0 +1,13 @@
+import Vue from 'our_vue'
+import NavBar from '../components/NavBar'
+
+export default function(el, {loggedIn = false}) {
+  new Vue({
+    el,
+    render(h) {
+      return h(NavBar, {
+        props: {loggedIn},
+      })
+    }
+  })
+}

--- a/app/javascript/entry_points/notice.js
+++ b/app/javascript/entry_points/notice.js
@@ -1,16 +1,15 @@
-import Vue from 'our_vue'
-import Notice from '../components/Notice'
+import {SnackbarProgrammatic as Snackbar} from 'buefy'
 
-export default function(el, {message, type}) {
-  new Vue({
-    el,
-    render(h) {
-      return h(Notice, {
-        props: {
-          message,
-          type,
-        },
-      })
-    }
+export default function({
+  message,
+  type,
+  indefinite = false,
+  position = 'is-top'
+}) {
+  Snackbar.open({
+    message,
+    type,
+    indefinite,
+    position,
   })
 }

--- a/app/javascript/entry_points/notice.js
+++ b/app/javascript/entry_points/notice.js
@@ -1,0 +1,16 @@
+import Vue from 'our_vue'
+import Notice from '../components/Notice'
+
+export default function(el, {message, type}) {
+  new Vue({
+    el,
+    render(h) {
+      return h(Notice, {
+        props: {
+          message,
+          type,
+        },
+      })
+    }
+  })
+}

--- a/app/javascript/our_vue.js
+++ b/app/javascript/our_vue.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import Buefy from 'buefy'
 
-Vue.use(Buefy)
+Vue.use(Buefy, {
+  defaultIconPack: 'fas',
+})
 
 export default Vue

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,47 +1,58 @@
 <nav class='navbar is-fixed-top is-white'>
-  <div class='navbar-brand'>
-    <div class='navbar-item'>
-      <a href='/'>
-        <%= image_tag 'logo.png', height: 300, alt: 'festi logo'%>
+  <div class="container">
+    <div class='navbar-brand'>
+      <div class='navbar-item'>
+        <a href='/'>
+          <%= image_tag 'logo.png', height: 300, alt: 'festi logo'%>
+        </a>
+      </div>
+      <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
       </a>
     </div>
-    <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-    </a>
-  </div>
-  <div class='navbar-menu'>
-    <div class="navbar-start">
-      <div class="navbar-item">
-        <%= link_to("About", about_public_path) %>
-      </div>
-      <div class="navbar-item">
-        <%= link_to("Share", share_public_path) %>
-      </div>
-      <div class="navbar-item">
-        <%= link_to("Community Resources", community_resources_public_path) %>
-      </div>
-      <div class="navbar-item">
-        <%= link_to("Announcements", news_and_announcements_public_path) %>
-      </div>
-    </div>
-    <div class="navbar-end">
-      <% if current_user %>
-        <div class='navbar-item'>
-          <%= link_to "Account", edit_user_registration_path %>
+    <div class='navbar-menu'>
+      <div class="navbar-start">
+        <div class="navbar-item">
+          <%= link_to("About", about_public_path) %>
         </div>
-        <div class='navbar-item'>
-          <%= link_to "Admin", landing_page_admin_path %>
+        <div class="navbar-item">
+          <%= link_to("Share", share_public_path) %>
         </div>
-        <div class='navbar-item'>
-          <%= link_to "Log out", destroy_user_session_path, method: :delete, no_confirm: true, :class=>"button is-danger is-outlined"%>
+        <div class="navbar-item">
+          <%= link_to("Community Resources", community_resources_public_path) %>
         </div>
-      <% else %>
-        <div class='navbar-item'>
-          <%= link_to "Log in", new_user_session_path, :class=>"button is-primary" %>
+        <div class="navbar-item">
+          <%= link_to("Announcements", news_and_announcements_public_path) %>
         </div>
-      <% end %>
+      </div>
+      <div class="navbar-end">
+        <% if current_user %>
+          <div class='navbar-item'>
+            <%= link_to "Account", edit_user_registration_path %>
+          </div>
+          <div class='navbar-item'>
+            <%= link_to "Admin", landing_page_admin_path %>
+          </div>
+          <div class='navbar-item'>
+            <%= link_to "Log out", destroy_user_session_path, method: :delete, no_confirm: true, :class=>"button is-danger is-outlined"%>
+          </div>
+        <% else %>
+          <div class='navbar-item'>
+            <%= link_to "Log in", new_user_session_path, :class=>"button is-primary" %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </nav>
+
+<script>
+  const burger = document.querySelector('.navbar-burger')
+  const menu = document.querySelector('.navbar-menu')
+  burger.addEventListener('click', ()=> {
+    burger.classList.toggle('is-active')
+    menu.classList.toggle('is-active')
+  })
+</script>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,58 +1,8 @@
-<nav class='navbar is-fixed-top is-white'>
-  <div class="container">
-    <div class='navbar-brand'>
-      <div class='navbar-item'>
-        <a href='/'>
-          <%= image_tag 'logo.png', height: 300, alt: 'festi logo'%>
-        </a>
-      </div>
-      <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
-        <span aria-hidden="true"></span>
-        <span aria-hidden="true"></span>
-        <span aria-hidden="true"></span>
-      </a>
-    </div>
-    <div class='navbar-menu'>
-      <div class="navbar-start">
-        <div class="navbar-item">
-          <%= link_to("About", about_public_path) %>
-        </div>
-        <div class="navbar-item">
-          <%= link_to("Share", share_public_path) %>
-        </div>
-        <div class="navbar-item">
-          <%= link_to("Community Resources", community_resources_public_path) %>
-        </div>
-        <div class="navbar-item">
-          <%= link_to("Announcements", news_and_announcements_public_path) %>
-        </div>
-      </div>
-      <div class="navbar-end">
-        <% if current_user %>
-          <div class='navbar-item'>
-            <%= link_to "Account", edit_user_registration_path %>
-          </div>
-          <div class='navbar-item'>
-            <%= link_to "Admin", landing_page_admin_path %>
-          </div>
-          <div class='navbar-item'>
-            <%= link_to "Log out", destroy_user_session_path, method: :delete, no_confirm: true, :class=>"button is-danger is-outlined"%>
-          </div>
-        <% else %>
-          <div class='navbar-item'>
-            <%= link_to "Log in", new_user_session_path, :class=>"button is-primary" %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </div>
-</nav>
-
+<div id="navBar"></div>
 <script>
-  const burger = document.querySelector('.navbar-burger')
-  const menu = document.querySelector('.navbar-menu')
-  burger.addEventListener('click', ()=> {
-    burger.classList.toggle('is-active')
-    menu.classList.toggle('is-active')
+  document.addEventListener('DOMContentLoaded', () => {
+    EntryPoints.navBar('#navBar', {
+      loggedIn: <%= current_user.present? %>,
+    })
   })
 </script>

--- a/app/views/layouts/_notices_and_alerts.html.erb
+++ b/app/views/layouts/_notices_and_alerts.html.erb
@@ -1,7 +1,7 @@
-<div class="col-md-12 text-center">
+<div class="notices-and-alerts container text-center">
   <div class="col-md-8 offset-md-2">
     <% if notice %>
-      <div class='section' id="notice">
+      <div id="notice">
         <div class="message" role="alert">
           <div class="message-header">
           <h1></h1>
@@ -24,7 +24,7 @@
     <% end %>
 
     <% if alert %>
-      <div class="section" id="alert">
+      <div id="alert">
         <div class="message" role="alert">
           <div class="message-header">
           <h1></h1>

--- a/app/views/layouts/_notices_and_alerts.html.erb
+++ b/app/views/layouts/_notices_and_alerts.html.erb
@@ -1,13 +1,10 @@
 <% if alert || notice %>
-  <div class="container">
-    <div id="notice"></div>
-  </div>
-
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      EntryPoints.notice('#notice', <%= raw({
+      EntryPoints.notice(<%= raw({
         message: alert ? alert : notice,
-        type: alert ? 'warning' : 'info',
+        type: alert ? 'is-danger' : 'is-info',
+        indefinite: alert.present?,
       }.to_json) %>)
     })
   </script>

--- a/app/views/layouts/_notices_and_alerts.html.erb
+++ b/app/views/layouts/_notices_and_alerts.html.erb
@@ -1,48 +1,14 @@
-<div class="notices-and-alerts container text-center">
-  <div class="col-md-8 offset-md-2">
-    <% if notice %>
-      <div id="notice">
-        <div class="message" role="alert">
-          <div class="message-header">
-          <h1></h1>
-            <button type="button" id="delete-notice" class="delete is-pulled-right" data-dismiss="alert" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="message-body">
-            <%= notice.html_safe %>
-          </div>
-        </div>
-      </div>
-      <script>
-        document.getElementById('delete-notice').addEventListener('click', e => {
-          const notice = document.getElementById('notice')
-          console.log("deleting", notice)
-          notice.parentNode.removeChild(notice)
-        })
-      </script>
-    <% end %>
-
-    <% if alert %>
-      <div id="alert">
-        <div class="message" role="alert">
-          <div class="message-header">
-          <h1></h1>
-            <button type="button" id="delete-alert" class="delete is-pulled-right" data-dismiss="alert" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="message-body">
-            <%= alert.html_safe %>
-          </div>
-        </div>
-      </div>
-      <script>
-        document.getElementById('delete-alert').addEventListener('click', e => {
-          const alert = document.getElementById('alert')
-          alert.parentNode.removeChild(alert)
-        })
-      </script>
-    <% end %>
+<% if alert || notice %>
+  <div class="container">
+    <div id="notice"></div>
   </div>
-</div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      EntryPoints.notice('#notice', <%= raw({
+        message: alert ? alert : notice,
+        type: alert ? 'warning' : 'info',
+      }.to_json) %>)
+    })
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,20 +12,19 @@
   </head>
 
   <body class='has-navbar-fixed-top'>
-  <%= render partial: "layouts/navbar" %>
-    <div class="notices-and-alerts">
-      <%= render partial: "layouts/notices_and_alerts" %>
-    </div>
-    <script>
-      const burger = document.querySelector('.navbar-burger')
-      const menu = document.querySelector('.navbar-menu')
-      burger.addEventListener('click', ()=> {
-        burger.classList.toggle('is-active')
-        menu.classList.toggle('is-active')
-      })
-    </script>
-    <div class="yield-body section" style="padding: 3em;">
+    <!-- TODO: implement skip-nav link, eg with vue-a00y/vue-skip-to -->
+
+    <%= render "layouts/navbar" %>
+    <%= render "layouts/notices_and_alerts" %>
+
+    <!--
+      Note: we use a single `.section` around <main> because most of our pages only need one.
+      The intention is to _not_ use `.section` anywhere else on the site. It's not designed
+      to be nested and it will be easier for us to use html <section> elements with some css
+      to give it vertical padding.
+    -->
+    <main class="section container">
       <%= yield %>
-    </div>
+    </main>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_pack_tag 'application' %>
   </head>
 
-  <body class='has-navbar-fixed-top'>
+  <body>
     <!-- TODO: implement skip-nav link, eg with vue-a00y/vue-skip-to -->
 
     <%= render "layouts/navbar" %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const { environment } = require('@rails/webpacker')
 const { VueLoaderPlugin } = require('vue-loader')
 const vue = require('./loaders/vue')
@@ -6,6 +7,11 @@ environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
 
 environment.config.merge({
+  resolve: {
+    alias: {
+      images:  path.resolve(__dirname, '../../app/assets/images'),
+    },
+  },
   output: {
     // Exposes the export from last pack (application.js) as a global var.
     // https://webpack.js.org/configuration/output/#outputlibrary

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mutualaid",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.13.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "babel-loader": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-loader": "^8.1.0",
     "buefy": "^0.8.17",
     "css-loader": "^3.5.2",
+    "file-loader": "^6.0.0",
     "style-loader": "^1.1.4",
     "vue": "^2.6.11",
     "vue-loader": "^15.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,6 +3107,14 @@ file-loader@^4.2.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
+file-loader@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.0.0.tgz#97bbfaab7a2460c07bcbd72d3a6922407f67649f"
+  integrity sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^2.6.5"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,6 +785,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
+  integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
## Several changes on the site-wide layout code
1. Get font-awesome working.
1. Cleanup `layouts/application.html.erb`.
1. Sort out `.container` and `.section` use in our site-wide layout (see notes below).
1. Switch `nav` to use `buefy`.
1. Extract reusable `DeleteButton` component.
1. Switch notices to use `buefy`.

See individual commit comments for more details.
May also be easier to review the changes one commit at a time.

## Notice/alert styling
Played around with two different buefy components for displaying notices:
### Message 
<img width="1032" alt="Screen Shot 2020-04-28 at 00 32 51" src="https://user-images.githubusercontent.com/8330/80447645-f821a980-88e7-11ea-86d8-8bb4a8c8f6dc.png">

### Snackbar
<img width="955" alt="Screen Shot 2020-04-28 at 00 29 47" src="https://user-images.githubusercontent.com/8330/80447522-97926c80-88e7-11ea-89b1-18605224a811.png">

I prefer the Snackbar, mostly because its less intrusive -- the Message banner takes up a lot of screen-space. Most of the time we'll be showing informational messages, so it feels a bit too heavy.
