### PR TITLE
Add more data to tiles

### DIFF
--- a/app/assets/stylesheets/listings.scss
+++ b/app/assets/stylesheets/listings.scss
@@ -27,11 +27,3 @@
     display: none;
   }
 }
-.tileBrowser-listItem {
-  &.box {
-    margin: 0.2em;
-  }
-  .tagList-tag {
-    margin: 0.1em;
-  }
-}

--- a/app/javascript/components/TagList.vue
+++ b/app/javascript/components/TagList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul v-if="isTagsValid" class="tagList tags" :class="listClasses">
+  <ul v-if="isTagsValid" class="tagList tags">
     <li v-for="tag in tags" :key="tag.id" class="tagList-tag tag" :class="tagClasses">
       {{ tag.name }}
     </li>
@@ -9,7 +9,6 @@
 <script>
 export default {
   props: {
-    listClasses: String,
     tagClasses: {type: String, default: 'is-info is-light'},
     tags: Array,
   },

--- a/app/javascript/components/TagList.vue
+++ b/app/javascript/components/TagList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul v-if="isTagsValid" class="tagList" :class="listClasses">
+  <ul v-if="isTagsValid" class="tagList tags" :class="listClasses">
     <li v-for="tag in tags" :key="tag.id" class="tagList-tag tag" :class="tagClasses">
       {{ tag.name }}
     </li>

--- a/app/javascript/pages/browse/ContactIcons.vue
+++ b/app/javascript/pages/browse/ContactIcons.vue
@@ -1,0 +1,31 @@
+<template>
+  <ul>
+    <li v-for="icon in iconData" :key="icon.name" class="tag">
+      <b-icon :icon="icon.image" :aria-label="icon.name"/>
+    </li>
+  </ul>
+</template>
+
+<script>
+import TagList from 'components/TagList'
+
+const iconNameMapping = {
+  email: 'envelope',
+  text: 'mobile-alt',
+  call: 'phone',
+}
+
+export default {
+  components: {TagList},
+  props: {
+    contactTypes: {type: Array, default: () => []},
+  },
+  computed: {
+    iconData() {
+      return this.contactTypes.map(function (type) {
+        return {name: type.name, image: iconNameMapping[type.name]}
+      })
+    },
+  },
+}
+</script>

--- a/app/javascript/pages/browse/TileBrowser.vue
+++ b/app/javascript/pages/browse/TileBrowser.vue
@@ -1,7 +1,6 @@
 <template>
   <section class="tileBrowser">
     <h2 class="title">Tile view</h2>
-    <div>
       <ul class="columns is-multiline is-centered">
         <TileListItem
           v-for="contribution in contributions"
@@ -10,7 +9,6 @@
           class="column is-one-quarter"
         />
       </ul>
-    </div>
   </section>
 </template>
 

--- a/app/javascript/pages/browse/TileBrowser.vue
+++ b/app/javascript/pages/browse/TileBrowser.vue
@@ -2,12 +2,12 @@
   <section class="tileBrowser">
     <h2 class="title">Tile view</h2>
     <div>
-      <ul class="columns">
+      <ul class="columns is-multiline is-centered">
         <TileListItem
           v-for="contribution in contributions"
           :key="contribution.id"
           v-bind="contribution"
-          class="column"
+          class="column is-one-quarter"
         />
       </ul>
     </div>

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -1,25 +1,43 @@
 <template>
-  <li class="tileBrowser-listItem box">
-    <div class="tileBrowser-listItem-categories">
-      <TagList :tags="category_tags" tagClasses="tag is-info is-light is-inline-flex" />
-    </div>
-    <div class="tileBrowser-listItem-body">
-      <TagList v-if="service_area" :tags="[service_area]" />
-      <h5 class="subtitle">{{ short_title }}</h5>
-      <p>{{ description }}</p>
-      <div>
-        <time :datetime="publish_until"></time>
+  <li class="tileListItem box is-paddingless">
+    <div class="header header--withShadow">
+      <div class="left-tags">
+        <TagList :tags="category_tags" class="categoryTags" tagClasses="tag is-info is-light" />
+      </div>
+      <div class="right-tags tags">
+        <b-tag :class="urgencyColor">
+          <b-icon v-if="showUrgentIcon" icon="exclamation-triangle" size="is-small" />
+          {{ urgency.name }}
+        </b-tag>
       </div>
     </div>
-    <div class="tileBrowser-listItem-actions">
-      <button class="button icon-list is-primary is-outlined">View Profile</button>
-      <button class="button icon-list is-primary is-outlined">Contact</button>
+    <div class="body">
+      <div class="tags">
+        <div v-if="service_area" class="tag is-info is-light">{{ service_area.name }}</div>
+        <ContactIcons :contactTypes="preferred_contact_types" />
+      </div>
+      <div class="text">
+        <h5 class="subtitle">{{ short_title }}</h5>
+        <p>{{ description }}</p>
+        <div>
+          <time :datetime="publish_until"></time>
+        </div>
+      </div>
+    </div>
+    <div class="actions">
+      <div class="buttonSpacing">
+        <button class="button icon-list is-primary is-outlined">View Profile</button>
+      </div>
+      <div class="buttonSpacing">
+        <button class="button icon-list is-primary is-outlined">Contact</button>
+      </div>
     </div>
   </li>
 </template>
 
 <script>
 import TagList from 'components/TagList'
+import ContactIcons from './ContactIcons'
 
 export default {
   props: {
@@ -28,9 +46,65 @@ export default {
     short_title: String,
     description: String,
     publish_until: String,
+    urgency: Object,
+    preferred_contact_types: {type: Array, default: () => []},
   },
   components: {
     TagList,
+    ContactIcons,
+  },
+  computed: {
+    showUrgentIcon() {
+      return this.urgency.id < 2
+    },
+    urgencyColor() {
+      return this.showUrgentIcon ? 'is-warning' : 'is-light is-warning'
+    },
   },
 }
 </script>
+
+<style lang="scss" scoped>
+@import 'bulma/bulma';
+
+.tileListItem {
+  @include tablet {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.2rem 0.3rem 0.3rem;
+  &--withShadow {
+    box-shadow: 0px 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
+  }
+  & div {
+    margin-top: 0.1rem;
+  }
+  & .left-tags {
+    flex-grow: 1;
+  }
+}
+.body {
+  padding: 0.3rem;
+  box-shadow: 0px 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
+  flex: auto;
+}
+.text {
+  margin: 0.2rem;
+}
+
+.actions {
+  margin: 0.1rem;
+}
+
+.buttonSpacing {
+  display: inline-block;
+  margin: 0.1rem;
+}
+</style>

--- a/lib/listings.json
+++ b/lib/listings.json
@@ -57,6 +57,41 @@
         {"id": 2, "name": "call"},
         {"id": 3, "name": "email"}
       ]
+    },
+    {
+      "id": 4,
+      "category_tags": [{"id": 3, "name": "Housework"}],
+      "availability": [{"id": 3, "name": "EVE"}],
+      "urgency": {"id": 3, "name": "I can wait a week"},
+      "created_at": "2020-04-11T04:17:31.288Z",
+      "publish_until": "2021-09-11",
+      "service_area": {"id": 1, "name": "East Bay"},
+      "contribution_type": {"id": 4, "name": "ask"},
+      "short_title": "bathroom help, like cleaning specifically if that's okay",
+      "description": "I'm afraid I'll fall and hurt my hip again. Can someone help me clean?",
+      "preferred_contact_types": [
+        {"id": 2, "name": "call"},
+        {"id": 3, "name": "email"}
+      ]
+    },
+    {
+      "id": 5,
+      "contribution_type": {"id": 1, "name": "ask"},
+      "category_tags": [{"id": 1, "name": "Care"}],
+      "availability": [
+        {"id": 1, "name": "AM"},
+        {"id": 1, "name": "PM"},
+        {"id": 1, "name": "EVE"}
+      ],
+      "urgency": {"id": 1, "name": "Within 1-2 days"},
+      "publish_until": "2021-10-11",
+      "publish_until_humanized": "this year",
+      "created_at": "2020-04-11T02:15:50.499Z",
+      "service_area": {"id": 1, "name": "East Bay"},
+      "map_location": "44.5,-85.1",
+      "short_title": "Look after my kid",
+      "description": "Lorem Ipsum is the name of my child. They are a very nice child. You won't have much trouble, but they are young and need the help",
+      "preferred_contact_types": [{"id": 1, "name": "text"}]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/webpacker": "4.2.2",
     "babel-loader": "^8.1.0",
     "buefy": "^0.8.17",
+    "bulma": "^0.8.2",
     "css-loader": "^3.5.2",
     "file-loader": "^6.0.0",
     "style-loader": "^1.1.4",
@@ -26,6 +27,7 @@
     "mocha-junit-reporter": "^1.23.3",
     "mochapack": "^1.1.15",
     "prettier": "2.0.5",
+    "sass-loader": "8.0.2",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",
     "webpack-node-externals": "^1.7.2"

--- a/spec/javascript/components/TagList.spec.js
+++ b/spec/javascript/components/TagList.spec.js
@@ -8,7 +8,7 @@ it('has default css classes', function () {
       tags: [{id: 1, name: 'a'}],
     },
   })
-  assert.equal(wrapper.classes(), 'tagList')
+  assert.deepEqual(wrapper.classes(), ['tagList', 'tags'])
   assert.deepEqual(wrapper.find('li').classes(), ['tagList-tag', 'tag', 'is-info', 'is-light'])
 })
 
@@ -20,7 +20,7 @@ it('can override some of the default classes', function () {
       tagClasses: 'childClass',
     },
   })
-  assert.deepEqual(wrapper.classes(), ['tagList', 'parentClass'])
+  assert.deepEqual(wrapper.classes(), ['tagList', 'tags', 'parentClass'])
   assert.deepEqual(wrapper.findAll('li').at(0).classes(), ['tagList-tag', 'tag', 'childClass'])
   assert.deepEqual(wrapper.findAll('li').at(1).classes(), ['tagList-tag', 'tag', 'childClass'])
 })

--- a/spec/javascript/components/TagList.spec.js
+++ b/spec/javascript/components/TagList.spec.js
@@ -3,7 +3,7 @@ import {shallowMount} from '@vue/test-utils'
 import TagList from 'components/TagList'
 
 it('has default css classes', function () {
-  var wrapper = shallowMount(TagList, {
+  const wrapper = shallowMount(TagList, {
     propsData: {
       tags: [{id: 1, name: 'a'}],
     },
@@ -13,24 +13,22 @@ it('has default css classes', function () {
 })
 
 it('can override some of the default classes', function () {
-  var wrapper = shallowMount(TagList, {
+  const wrapper = shallowMount(TagList, {
     propsData: {
       tags: [{id: 2, name: 'b'}, [{id: 3, name: 'c'}]],
-      listClasses: 'parentClass',
       tagClasses: 'childClass',
     },
   })
-  assert.deepEqual(wrapper.classes(), ['tagList', 'tags', 'parentClass'])
   assert.deepEqual(wrapper.findAll('li').at(0).classes(), ['tagList-tag', 'tag', 'childClass'])
   assert.deepEqual(wrapper.findAll('li').at(1).classes(), ['tagList-tag', 'tag', 'childClass'])
 })
 
 it('renders empty if the tags are invalid', function () {
-  var nullWrapper = shallowMount(TagList, {
+  const nullWrapper = shallowMount(TagList, {
     propsData: {tags: null},
   })
-  var emptyWrapper = shallowMount(TagList, {propsData: {tags: []}})
-  var nullEmptyWrapper = shallowMount(TagList, {propsData: {tags: [null]}})
+  const emptyWrapper = shallowMount(TagList, {propsData: {tags: []}})
+  const nullEmptyWrapper = shallowMount(TagList, {propsData: {tags: [null]}})
   assert.isTrue(nullWrapper.isEmpty())
   assert.isTrue(emptyWrapper.isEmpty())
   assert.isTrue(nullEmptyWrapper.isEmpty())

--- a/spec/javascript/pages/browse/ContactIcons.spec.js
+++ b/spec/javascript/pages/browse/ContactIcons.spec.js
@@ -3,7 +3,7 @@ import {shallowMount} from '@vue/test-utils'
 import ContactIcons from 'pages/browse/ContactIcons'
 
 it('generally works', function() {
-  var wrapper = shallowMount(ContactIcons, {
+  const wrapper = shallowMount(ContactIcons, {
     propsData: { contactTypes: [{id: 1, name: "email"}, {id: 2, name: "text"},{id: 3, name: "call"}]}
   })
   assert.exists(wrapper.find('b-icon-stub[aria-label=email][icon=envelope]').text())

--- a/spec/javascript/pages/browse/ContactIcons.spec.js
+++ b/spec/javascript/pages/browse/ContactIcons.spec.js
@@ -1,0 +1,11 @@
+import Vue from 'our_vue'
+import {shallowMount} from '@vue/test-utils'
+import ContactIcons from 'pages/browse/ContactIcons'
+
+it('generally works', function() {
+  var wrapper = shallowMount(ContactIcons, {
+    propsData: { contactTypes: [{id: 1, name: "email"}, {id: 2, name: "text"},{id: 3, name: "call"}]}
+  })
+  assert.exists(wrapper.find('b-icon-stub[aria-label=email][icon=envelope]').text())
+  assert.exists(wrapper.find('b-icon-stub[aria-label=call][icon=phone]').text())
+})

--- a/spec/javascript/pages/browse/ListBrowser.spec.js
+++ b/spec/javascript/pages/browse/ListBrowser.spec.js
@@ -1,10 +1,10 @@
 import {assert} from 'chai'
 import {mount} from '@vue/test-utils'
 import ListBrowser from 'pages/browse/ListBrowser'
+import testData from '../../../../lib/listings.json'
 
 it('works with reasonable data', function () {
-  const testData = require('../../../../lib/listings.json')
-  var wrapper = mount(ListBrowser, {
+  const wrapper = mount(ListBrowser, {
     propsData: {
       contributions: testData.contributions,
     },

--- a/spec/javascript/pages/browse/TileBrowser.spec.js
+++ b/spec/javascript/pages/browse/TileBrowser.spec.js
@@ -5,7 +5,7 @@ import TileBrowser from 'pages/browse/ListBrowser'
 it('works with reasonable data', function () {
   const testData = require('../../../../lib/listings.json')
 
-  var wrapper = mount(TileBrowser, {
+  const wrapper = mount(TileBrowser, {
     propsData: {
       contributions: testData.contributions,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,11 @@ bulma@0.7.5:
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.5.tgz#35066c37f82c088b68f94450be758fc00a967208"
   integrity sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw==
 
+bulma@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.8.2.tgz#5d928f16ed4a84549c2873f95c92c38c69c631a7"
+  integrity sha512-vMM/ijYSxX+Sm+nD7Lmc1UgWDy2JcL2nTKqwgEqXuOMU+IGALbXd5MLt/BcjBAPLIx36TtzhzBcSnOP974gcqA==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -6928,6 +6933,17 @@ sass-loader@7.3.1:
     loader-utils "^1.0.1"
     neo-async "^2.5.0"
     pify "^4.0.1"
+    semver "^6.3.0"
+
+sass-loader@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.6.1"
     semver "^6.3.0"
 
 sax@~1.2.4:


### PR DESCRIPTION
I've got this so it looks fine on mobile, and on larger screens. There's some weirdness at intermediate sizes, which I'll post screenshots at below. I'm still learning a lot about CSS, haven't really done much with flexbox before now, so suggestions are welcome.

Also, I'm not really happy with how the content of these `<style>` tags in the components look. The feel rambling and hard to scan to me. I'd definitely appreciate organizational suggestions for them

### Screenshots
## Problems with intermediate sizes

Not sure how best to deal with this (see pointy arrow) behavior where the tags are too big to fit. I figure it's a UI problem because for some people it will break their ability to scan through the cards easily.

<img width="801" alt="Screen Shot 2020-05-01 at 8 22 17 PM" src="https://user-images.githubusercontent.com/3620291/80850467-f9095280-8be9-11ea-9e93-dfbd2a213384.png">



I like wrapping better than the ol' css overflow.

![css-mug-3](https://user-images.githubusercontent.com/3620291/80850550-64ebbb00-8bea-11ea-91eb-fc3db1badc9a.jpg)

I think it's more important to move on to filtering functionality first. I mean, I could keep going with these tiles and fiddle around with various properties to get the behavior I'm looking for. There are also other UI touch-ups I'd like to do. And there are more that we'll notice or stakeholders will ask for. I have a soft preference to do them in a batch later instead of now when I feel like I'm at a good transition point.

## Mobile

<img width="389" alt="Screen Shot 2020-05-01 at 8 19 14 PM" src="https://user-images.githubusercontent.com/3620291/80850279-125dcf00-8be9-11ea-811f-27ca25dc3f1f.png">

## Large

<img width="1142" alt="Screen Shot 2020-05-01 at 8 29 54 PM" src="https://user-images.githubusercontent.com/3620291/80850577-8a78c480-8bea-11ea-9278-b51994afb28f.png">
