### PR TITLE
Send autoemails and log after submission create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include DeliverNowWithErrorHandling
 
   protect_from_forgery with: :exception
   before_action :authenticate_user!

--- a/app/controllers/communication_logs_controller.rb
+++ b/app/controllers/communication_logs_controller.rb
@@ -2,7 +2,7 @@ class CommunicationLogsController < ApplicationController
   before_action :set_communication_log, only: [:show, :edit, :update, :destroy]
 
   def index
-    @communication_logs = CommunicationLog.all
+    @communication_logs = CommunicationLog.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/concerns/deliver_now_with_error_handling.rb
+++ b/app/controllers/concerns/deliver_now_with_error_handling.rb
@@ -1,0 +1,16 @@
+module DeliverNowWithErrorHandling
+  extend ActiveSupport::Concern
+
+  def deliver_now_with_error_handling(autoemail, mailer_view_name=nil)
+    delivery_status = CommunicationLog::DEFAULT_DELIVERY_STATUS
+    begin
+      autoemail.deliver_now
+    rescue => e
+      delivery_status = "FAILED #{e}"
+      Rails.logger.info("=============BEGIN ERROR/PROBLEM WITH EMAIL DELIVERY: #{mailer_view_name}=================")
+      Rails.logger.info("============= #{e} =================")
+      Rails.logger.info("=============END ERROR/PROBLEM WITH EMAIL DELIVERY: #{mailer_view_name}=================")
+    end
+    delivery_status
+  end
+end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,7 +2,7 @@ class SubmissionsController < ApplicationController
   before_action :set_submission, only: [:show, :edit, :update, :destroy]
 
   def index
-    @submissions = Submission.all
+    @submissions = Submission.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -20,8 +20,19 @@ class SubmissionsController < ApplicationController
 
     respond_to do |format|
       if @submission.save
-        format.html { redirect_to submissions_path, notice: 'Position was successfully created.' }
-        format.json { render :show, status: :created, location: @submission }
+        Rails.logger.info "----------------SEND EMAIL CONFIRMATION"
+        # send the email
+        autoemail = SubmissionMailer.new_submission_confirmation_email(@submission)
+        delivery_status = deliver_now_with_error_handling(autoemail, "new_submission_confirmation_email")
+
+        # store email that was sent
+        CommunicationLog.log_submission_email(autoemail, delivery_status, @submission, CommunicationLog::AUTO_DELIVERY_CHANNEL, current_user)
+
+        format.html { redirect_to submissions_path,
+                                  notice: 'Submission successfully created.' }
+        format.json { render :new,
+                             status: :created,
+                             location: @submission }
       else
         format.html { render :new }
         format.json { render json: @submission.errors, status: :unprocessable_entity }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
     "<span class='#{ boolean ? "fa fa-check-circle has-text-success" : "fa fa-ban" }'></span>".html_safe
   end
 
-  def edit_button(resource)
+  def edit_button(resource, button_text="Edit")
     if resource && action_name != "edit"
       if resource.class.superclass != ApplicationRecord
         resource = resource.becomes(resource.class.superclass)
@@ -12,7 +12,7 @@ module ApplicationHelper
       link_to(edit_polymorphic_path(resource),
               title: action_name + " " + controller_path,
               class: 'button edit-button') do
-        "<span class='fa fa-edit'></span><span style='padding-left: 0.25em'> Edit</span>".html_safe
+        "<span class='fa fa-edit'></span><span style='padding-left: 0.25em'> #{button_text}</span>".html_safe
       end
     end
   end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -6,13 +6,16 @@ class SubmissionMailer < ApplicationMailer
   def new_submission_confirmation_email(submission)
     @submission = submission
 
+    current_organization = Organization.current_organization
+    @organization_name = current_organization.name
+
     @form_name = @submission.form_name
     if @form_name.downcase.include?("ask")
-      @form_contact = Organization.current_organization.ask_form_contact
+      @form_contact = current_organization.ask_form_contact
     elsif @form_name.downcase.include?("offer")
-      @form_contact = Organization.current_organization.offer_form_contact
+      @form_contact = current_organization.offer_form_contact
     elsif @form_name.downcase.include?("community_resource")
-      @form_contact = Organization.current_organization.community_resources_contact
+      @form_contact = current_organization.community_resources_contact
     end
 
     @person = @submission.person
@@ -20,15 +23,19 @@ class SubmissionMailer < ApplicationMailer
 
     @system_settings = SystemSetting.current_settings
 
-    system_email = "#{ENV["SYSTEM_EMAIL"]}"
-    email_with_name = %("#{system_email}" <#{system_email}>)
+    system_email = ENV["SYSTEM_EMAIL"]
+    sendgrid_from_email = ENV["SENDGRID_FROM_EMAIL"]
+    contact_email = @form_contact&.person&.email || "#{sendgrid_from_email}"
+    contact_name =  @form_contact&.person&.name || @form_contact&.name || contact_email
+    contact_email_with_name = %("#{contact_name} (#{Organization.current_organization.name})" <#{contact_email}>)
+    bcc_emails = [contact_email, sendgrid_from_email, system_email].uniq.join("; ")
 
     @subject =  "#{ENV["SYSTEM_APP_NAME"]} confirmation (" + @person.updated_at.to_date.to_s + ")"
 
     mail(to: @person.email,
-         from: email_with_name,
-         bcc: system_email,
-         reply_to: email_with_name.to_s + ", " + system_email.to_s,
+         from: contact_email_with_name,
+         bcc: bcc_emails,
+         reply_to: contact_email_with_name.to_s + ", " + system_email.to_s,
          subject: @subject) do |format|
       format.html { render template_path: 'submission_mailer',
                            template_name: 'new_submission_confirmation_email' }

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,0 +1,37 @@
+require "#{Rails.root}/app/helpers/application_helper.rb"
+include ApplicationHelper
+
+class SubmissionMailer < ApplicationMailer
+
+  def new_submission_confirmation_email(submission)
+    @submission = submission
+
+    @form_name = @submission.form_name
+    if @form_name.downcase.include?("ask")
+      @form_contact = Organization.current_organization.ask_form_contact
+    elsif @form_name.downcase.include?("offer")
+      @form_contact = Organization.current_organization.offer_form_contact
+    elsif @form_name.downcase.include?("community_resource")
+      @form_contact = Organization.current_organization.community_resources_contact
+    end
+
+    @person = @submission.person
+    @locale = @person.preferred_locale || 'en'
+
+    @system_settings = SystemSetting.current_settings
+
+    system_email = "#{ENV["SYSTEM_EMAIL"]}"
+    email_with_name = %("#{system_email}" <#{system_email}>)
+
+    @subject =  "#{ENV["SYSTEM_APP_NAME"]} confirmation (" + @person.updated_at.to_date.to_s + ")"
+
+    mail(to: @person.email,
+         from: email_with_name,
+         bcc: system_email,
+         reply_to: email_with_name.to_s + ", " + system_email.to_s,
+         subject: @subject) do |format|
+      format.html { render template_path: 'submission_mailer',
+                           template_name: 'new_submission_confirmation_email' }
+    end
+  end
+end

--- a/app/models/communication_log.rb
+++ b/app/models/communication_log.rb
@@ -6,4 +6,16 @@ class CommunicationLog < ApplicationRecord
   DEFAULT_DELIVERY_STATUS = "completed"
   AUTO_DELIVERY_CHANNEL = "autoemail"
   DELIVERY_CHANNELS = [AUTO_DELIVERY_CHANNEL, "email", "text", "call", "snailmail"]
+
+  def self.log_submission_email(email_object, delivery_status, submission, delivery_channel=nil, current_user=nil)
+    delivery_channel ||= AUTO_DELIVERY_CHANNEL
+    self.create!(delivery_channel: delivery_channel,
+                 delivery_status: delivery_status,
+                 person: submission.person,
+                 sent_at: Time.now,
+                 subject: email_object.subject,
+                 body: email_object.html_part&.body || email_object.body.raw_source,
+                 created_by: current_user
+    )
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,7 +7,23 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true
 
+  def self.current_organization
+    self.where(is_instance_owner: first).first
+  end
+
   def primary_contact
     positions.find_by(is_primary: true)
+  end
+
+  def ask_form_contact
+    positions.where(position_type: Position::ASK_FORM_CONTACT_TITLE, organization: Organization.current_organization).first
+  end
+
+  def offer_form_contact
+    positions.where(position_type: Position::OFFER_FORM_CONTACT_TITLE, organization: Organization.current_organization).first
+  end
+
+  def community_resources_contact
+    positions.where(position_type: Position::COMMUNITY_RESOURCES_CONTACT_TITLE, organization: Organization.current_organization).first
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -3,6 +3,8 @@ class Person < ApplicationRecord
   belongs_to :service_area, optional: true
   belongs_to :location, optional: true
 
+  has_many :communication_logs
+
   has_many :asks, inverse_of: :person
   has_many :offers, inverse_of: :person
   has_many :listings

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -1,5 +1,14 @@
 class Position < ApplicationRecord
   belongs_to :organization
-  belongs_to :person
+  belongs_to :person, optional: true
 
+  ASK_FORM_CONTACT_TITLE = "ASK_FORM_CONTACT"
+  OFFER_FORM_CONTACT_TITLE = "OFFER_FORM_CONTACT"
+  COMMUNITY_RESOURCES_CONTACT_TITLE = "COMMUNITY_RESOURCES_CONTACT"
+  FORM_CONTACT_TITLES = [ASK_FORM_CONTACT_TITLE, OFFER_FORM_CONTACT_TITLE,
+                         COMMUNITY_RESOURCES_CONTACT_TITLE, "Point of contact", "Member"]
+
+  def name
+    "#{person.name + ", " if person.present?}#{position_type} "
+  end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -9,6 +9,6 @@ class Position < ApplicationRecord
                          COMMUNITY_RESOURCES_CONTACT_TITLE, "Point of contact", "Member"]
 
   def name
-    "#{person.name + ", " if person.present?}#{position_type} "
+    "#{person.name + ", " if person.present?}#{position_type}"
   end
 end

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -1,2 +1,56 @@
 class SystemSetting < ApplicationRecord
+
+  EXCHANGE_TYPES = [
+      "fully_moderated", # no public access
+      "dispatch_moderated",  # peer-to-peer, but
+      "moderation_on_request", # option on Forms to request hidden from public and/or messaging moderation
+      "dispatch_assisted",  # peer-to-peer, but admins (dispatch/connectors/coordinators) can also complete matches
+      "peer_to_peer" # everything is public
+  ]
+
+  # everything is public, including contact info
+  # everything is public, but messaging is deidentified
+  # things are optionally public, but request to connect is moderated by dispatch
+  # things are optionally public, and deidentified messaging is an option
+  #
+  ### contribution display settings
+  # all contributions are public
+  # contributions are optionally public
+  # no contributions are public
+  # all contributions are visible to people with accounts
+  # some contributions are visible to people with accounts
+  #
+  ### messaging settings
+  # people are able to find each other's contact info
+  # people are able to message each other (deidentified, a la craigslist)
+  # people are able to message each other, but can request messages be tracked/moderated
+  # people are not able to contact each other, but can request to be connected with specific contributions
+  # people only contact dispatch
+  #
+
+  def self.current_settings
+    self.last
+  end
+
+
+  def dispatch_assisted?
+    exchange_type == "dispatch_assisted"
+  end
+
+  def dispatch_moderated?
+    exchange_type == "dispatch_moderated"
+  end
+
+  def fully_moderated?
+    exchange_type == "fully_moderated"
+  end
+
+  def moderation_on_request?
+    exchange_type == "moderation_on_request"
+  end
+
+  def peer_to_peer?
+    exchange_type == "peer_to_peer"
+  end
+
 end

--- a/app/views/communication_logs/_form.html.erb
+++ b/app/views/communication_logs/_form.html.erb
@@ -15,7 +15,9 @@
     <%= f.input :delivery_status, default: CommunicationLog::DEFAULT_DELIVERY_STATUS %>
 
     <%= f.input :subject, as: :text, input_html: { rows: 1 } %>
-    <%= f.input :body, as: :text, input_html: { rows: 4 } %>
+
+    <hr>
+    <%= f.object.body&.html_safe || "-- Empty --" %>
   </div>
 
   <%= render "layouts/view_footer_buttons", f: f, resource: @communication_log, top_divider: true, extra_form_button_1: nil, extra_form_button_2: nil %>

--- a/app/views/communication_logs/show.html.erb
+++ b/app/views/communication_logs/show.html.erb
@@ -1,16 +1,19 @@
 <%= render "layouts/view_header", resource: @communication_log %>
 
 <div class="section-detail">
-  <p id="notice"><%= notice %></p>
-
   <p>
     <strong>Person:</strong>
-    <%= @communication_log.person_id %>
+    <%= @communication_log.person&.name %>
   </p>
 
   <p>
-    <strong>Channel:</strong>
-    <%= @communication_log.channel %>
+    <strong>Delivery channel:</strong>
+    <%= @communication_log.delivery_channel %>
+  </p>
+
+  <p>
+    <strong>Delivery status:</strong>
+    <%= @communication_log.delivery_status %>
   </p>
 
   <p>
@@ -20,8 +23,20 @@
 
   <p>
     <strong>Needs follow up:</strong>
-    <%= @communication_log.needs_follow_up %>
+    <%= yes_no(@communication_log.needs_follow_up) %>
   </p>
+
+  <p>
+    <strong>Subject:</strong>
+    <%= @communication_log.subject %>
+  </p>
+
+  <p>
+    <strong>Body:</strong>
+    <%= @communication_log.body&.html_safe %>
+  </p>
+
+  <hr>
 
   <%= link_to 'Edit', edit_communication_log_path(@communication_log) %>
 </div>

--- a/app/views/layouts/_view_header.html.erb
+++ b/app/views/layouts/_view_header.html.erb
@@ -25,8 +25,10 @@
       <%= page_title %>
     </div>
 
-    <div class="section-detail">
-      <%= render 'form', singular_table_name => resource %>
-    </div>
+    <% if view_action_name == "edit" %>
+      <div class="section-detail">
+        <%= render 'form', singular_table_name => resource %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/submission_mailer/_generic_confirmation_email.html.erb
+++ b/app/views/submission_mailer/_generic_confirmation_email.html.erb
@@ -3,7 +3,7 @@
 
   <div><b>Hello there, <%= person_first_name %></b>,</div>
   <br>
-  <div>Thank you for your response to <%= Organization.current_organization %>'s <%= @form_name %>!</div>
+  <div>Thank you for your response to <%= @organization_name %>'s <%= @form_name %>!</div>
 
   <div>
     <% if @submission.moderation_requested? || @system_settings.dispatch_moderated? %>
@@ -23,7 +23,7 @@
 
   <br>
   <div>Take care,</div>
-  <div><%= Organization.current_organization %></div>
+  <div><%= @organization_name %></div>
 
   <br>
   <hr>

--- a/app/views/submission_mailer/_generic_confirmation_email.html.erb
+++ b/app/views/submission_mailer/_generic_confirmation_email.html.erb
@@ -1,0 +1,31 @@
+<div class="col-md-12">
+  <% person_first_name = @person&.first_name.to_s %>
+
+  <div><b>Hello there, <%= person_first_name %></b>,</div>
+  <br>
+  <div>Thank you for your response to <%= Organization.current_organization %>'s <%= @form_name %>!</div>
+
+  <div>
+    <% if @submission.moderation_requested? || @system_settings.dispatch_moderated? %>
+      We’ll contact you within a few days to see if we can be of assistance.
+    <% elsif @system_settings.peer_to_peer? %>
+      We hope you're contacted soon by a neighbor!
+    <% elsif @system_settings.hybrid? %>
+      We hope you're contacted soon by a neighbor or by our group. If your need is urgent and you still haven't been contacted, reach out to us directly.
+    <% end %>
+  </div>
+
+  <br>
+  <div>
+    If you have any questions, please contact <%= @form_contact&.name || "#{ENV["SYSTEM_APP_NAME"]}" %><%= " at " + mail_to(@form_contact.email) if @form_contact&.person_id %>.
+  </div>
+
+
+  <br>
+  <div>Take care,</div>
+  <div><%= Organization.current_organization %></div>
+
+  <br>
+  <hr>
+  <%= sanitize(render "submission_mailer/generic_show_for_email") %>
+</div>

--- a/app/views/submission_mailer/_generic_show_for_email.html.erb
+++ b/app/views/submission_mailer/_generic_show_for_email.html.erb
@@ -1,0 +1,24 @@
+<hr><hr>
+<div>
+  <div>
+    <h1 data-object="submission">
+      <%= @person.name %>
+    </h1>
+  </div>
+  <p>Email:
+    <% if @person.email.present? %>
+      <%= mail_to(@person.email) %>
+    <% else %>
+      <%= "No email on record." %>
+    <% end %>
+    Phone: <%= @person.phone %></p>
+  <p><%= "(" + @person.location&.full_name + ")" if @person.location_id %></p>
+
+  <br>
+
+  <div>
+    <hr>
+    <%#= render partial: "submissions/submission_responses", locals: {email_display: true} %>
+    <hr>
+  </div>
+</div>

--- a/app/views/submission_mailer/new_submission_confirmation_email.html.erb
+++ b/app/views/submission_mailer/new_submission_confirmation_email.html.erb
@@ -1,0 +1,2 @@
+<% mailer_partial = "submission_mailer/generic_confirmation_email" %>
+<%= render mailer_partial, :formats => [:html] %>

--- a/app/views/submission_mailer/new_submission_confirmation_email.text.erb
+++ b/app/views/submission_mailer/new_submission_confirmation_email.text.erb
@@ -1,0 +1,2 @@
+<% mailer_partial = "submission_mailer/generic_confirmation_email" %>
+<%= sanitize(render mailer_partial) %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -10,7 +10,8 @@
     <br><br>
     <%= f.input :form_name %>
     <%= f.input :privacy_level_requested %>
-    <%= f.input :body, readonly: true %>
+    <hr>
+    <%= f.object.body&.html_safe || "-- Empty --" %>
   </div>
 
   <%= render "layouts/view_footer_buttons", f: f, record: @submission, top_divider: true, extra_form_button_1: nil, extra_form_button_2: nil %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -8,6 +8,7 @@
         <th>Service area</th>
         <th>Form name</th>
         <th>Body</th>
+        <th>Autoemail</th>
         <th>Edit</th>
       </tr>
     </thead>
@@ -19,6 +20,7 @@
         <td><%= submission.service_area_id %></td>
         <td><%= submission.form_name %></td>
         <td><%= submission.body %></td>
+        <td><%= edit_button(submission.person.communication_logs.last, "View autoemail") if submission.person&.communication_logs&.any? %></td>
         <td><%= edit_button(submission) %></td>
       </tr>
     <% end %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -2,12 +2,12 @@
 
 <p>
   <strong>Person:</strong>
-  <%= @submission.person_id %>
+  <%= @submission.person&.name %>
 </p>
 
 <p>
   <strong>Service area:</strong>
-  <%= @submission.service_area_id %>
+  <%= @submission.service_area&.name %>
 </p>
 
 <p>
@@ -16,9 +16,17 @@
 </p>
 
 <p>
-  <strong>Body:</strong>
-  <%= @submission.body %>
+  <strong>Created at:</strong>
+  <%= @submission.created_at %>
 </p>
+
+
+<p>
+  <strong>Body:</strong>
+  <%= @submission.body&.html_safe %>
+</p>
+
+<hr>
 
 <%= link_to 'Edit', edit_submission_path(@submission) %> |
 <%= link_to 'Back', submissions_path %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,8 +10,7 @@ Category::DEFAULT_TAGS.each do |tag_name_parent, subtag_name|
 end
 
 host_organization = Organization.where(is_instance_owner: true).first_or_create!(name: "[CHANGEME] Default Mutual Aid Group")
-
-default_system_settings = SystemSetting.create!
+default_system_settings = SystemSetting.first_or_create!
 
 Position.where(position_type: Position::ASK_FORM_CONTACT_TITLE, organization: host_organization).first_or_create!
 Position.where(position_type: Position::OFFER_FORM_CONTACT_TITLE, organization: host_organization).first_or_create!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,4 +9,12 @@ Category::DEFAULT_TAGS.each do |tag_name_parent, subtag_name|
   end
 end
 
+host_organization = Organization.where(is_instance_owner: true).first_or_create!(name: "[CHANGEME] Default Mutual Aid Group")
+
+default_system_settings = SystemSetting.create!
+
+Position.where(position_type: Position::ASK_FORM_CONTACT_TITLE, organization: host_organization).first_or_create!
+Position.where(position_type: Position::OFFER_FORM_CONTACT_TITLE, organization: host_organization).first_or_create!
+Position.where(position_type: Position::COMMUNITY_RESOURCES_CONTACT_TITLE, organization: host_organization).first_or_create!
+
 puts "completed seeds.rb"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 user = User.where(email: "#{ENV["SYSTEM_EMAIL"]}").first_or_create!(password: "#{ENV["SYSTEM_PASSWORD"]}")
-user.confirmed_at = Time.now
+user.confirmed_at = Time.now # we currently have Devise :confirmable strategy turned on, so all new users need their email confirmed
 user.save!
 
 Category::DEFAULT_TAGS.each do |tag_name_parent, subtag_name|


### PR DESCRIPTION
This PR creates plumbing for sending confirmation emails after form "Submissions" are created, and then logging the autoemail in a `CommunicationLog`. It includes `SubmissionMailer` mailer file and view templates.

This process of sending autoemails requires some built-in knowledge within the system of who within the `Organization` should get notified of new `submissions` and be suggested to an unauthenticated user  as a point of contact for questions.

It starts to tease out some more detail wrt `SystemSettings`, system `exchange_types`, and the overall workflow, which will later inform a state machine on `Listing`.

* Add mailer and views for confirmation emails
* Change `SubmissionsController` create action so emails are sent after `@submission.save`
* Add `DeliverNowWithErrorHandling` concern to send emails and catch errors
* Add method to `communication_log.rb` to create submission confirmation email log
* Change order on `CommunicationLogsController` and `SubmissionsController` indexes so newest is on top
* Change display of body on `CommunicationLog` and `Submission` `form` and `show` partials/pages
* Change `seeds.rb` to first_or_create a current_organization and a `SystemSetting` record, and to create a Position for each form_type: `ask`, `offer`, `community_resource`
* Add class and instance methods to `Organization` to find who to tell users to contact with questions, and from whom emails will be "sent"
* Allow `Position` to be created even when there isn't a designated `Person` in the role
* Add array of possible `position_type` values (`FORM_CONTACT_TITLES`) -- this could def have a better name
* Added start of `EXCHANGE_TYPE` values to `SystemSetting`, which is also the beginnings of getting a solid state machine workflow in place -- lots of questions here around possible settings to provide to instances. Also added some helper methods for these settings so conditional logic for emails can be implemented.
* Change view_header to only show form if `view_action_name == "edit"`
* Change `edit_button` helper to allow text override (so it can be used on Submissions index to view the related communication_log -- rn that's accessed via person, and that's a little wonky. we might want to associate logs directly to Submission?)