### PR TITLE
Add locale to person

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -64,6 +64,7 @@ class PeopleController < ApplicationController
                                      :skills,
                                      :notes,
                                      :user_id,
+                                     :preferred_locale,
                                      :preferred_contact_timeframe,
                                      :preferred_contact_method)
     end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -8,6 +8,7 @@
     <%= f.input :email %>
     <%= f.input :phone_2 %>
     <%= f.input :email_2 %>
+    <%= f.input :preferred_locale %>
     <%= f.input :preferred_contact_method %>
     <%= f.input :preferred_contact_timeframe %>
     <%= f.input :skills %>

--- a/db/migrate/20200503224311_add_preferred_locale_to_person.rb
+++ b/db/migrate/20200503224311_add_preferred_locale_to_person.rb
@@ -1,0 +1,5 @@
+class AddPreferredLocaleToPerson < ActiveRecord::Migration[6.0]
+  def change
+    add_column :people, :preferred_locale, :string, null: false, default: "en"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,6 +223,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_224311) do
     t.bigint "location_id"
     t.bigint "service_area_id"
     t.bigint "user_id"
+    t.string "preferred_locale", default: "en", null: false
     t.index ["location_id"], name: "index_people_on_location_id"
     t.index ["service_area_id"], name: "index_people_on_service_area_id"
     t.index ["user_id"], name: "index_people_on_user_id"


### PR DESCRIPTION
Add `preferred_locale` to Person

Not adding this to User, bc we want to know everyone's preferred locale for ease of communications between volunteers/coordinators/providers/receivers.

We reference this value when sending Submission confirmation emails, but aren't yet rigged up for sending confirmation emails in different languages.