### PR TITLE
Some improvements to our JS specs

### DIFF
--- a/app/javascript/entry_points/browse.js
+++ b/app/javascript/entry_points/browse.js
@@ -1,4 +1,4 @@
-import Vue from 'our_vue'
+import Vue from 'vue_config'
 import Browse from 'pages/Browse'
 
 export default function(el, properties) {

--- a/app/javascript/entry_points/navBar.js
+++ b/app/javascript/entry_points/navBar.js
@@ -1,4 +1,4 @@
-import Vue from 'our_vue'
+import Vue from 'vue_config'
 import NavBar from '../components/NavBar'
 
 export default function(el, {loggedIn = false}) {

--- a/app/javascript/entry_points/orientation.js
+++ b/app/javascript/entry_points/orientation.js
@@ -1,4 +1,4 @@
-import Vue from 'our_vue'
+import Vue from 'vue_config'
 import Orientation from 'pages/Orientation'
 
 export default function(el, {organization}='Mutual-aid') {

--- a/app/javascript/entry_points/publicListings.js
+++ b/app/javascript/entry_points/publicListings.js
@@ -1,4 +1,4 @@
-import Vue from 'our_vue'
+import Vue from 'vue_config'
 import PublicListings from 'components/PublicListings'
 
 export default function(el) {

--- a/app/javascript/our_vue.js
+++ b/app/javascript/our_vue.js
@@ -1,8 +1,0 @@
-import Vue from 'vue'
-import Buefy from 'buefy'
-
-Vue.use(Buefy, {
-  defaultIconPack: 'fas',
-})
-
-export default Vue

--- a/app/javascript/vue_config.js
+++ b/app/javascript/vue_config.js
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+import Buefy from 'buefy'
+
+export function configure(vue) {
+  vue.use(Buefy, {
+    defaultIconPack: 'fas',
+  })
+
+  return vue
+}
+
+export default configure(Vue)

--- a/lib/listings.json
+++ b/lib/listings.json
@@ -7,8 +7,8 @@
       "category_tags": [{"id": 1, "name": "Care"}],
       "availability": [
         {"id": 1, "name": "AM"},
-        {"id": 1, "name": "PM"},
-        {"id": 1, "name": "EVE"}
+        {"id": 2, "name": "PM"},
+        {"id": 3, "name": "EVE"}
       ],
       "urgency": {"id": 1, "name": "Within 1-2 days"},
       "publish_until": "2021-10-11",
@@ -80,8 +80,8 @@
       "category_tags": [{"id": 1, "name": "Care"}],
       "availability": [
         {"id": 1, "name": "AM"},
-        {"id": 1, "name": "PM"},
-        {"id": 1, "name": "EVE"}
+        {"id": 2, "name": "PM"},
+        {"id": 3, "name": "EVE"}
       ],
       "urgency": {"id": 1, "name": "Within 1-2 days"},
       "publish_until": "2021-10-11",

--- a/spec/javascript/components/TagList.spec.js
+++ b/spec/javascript/components/TagList.spec.js
@@ -2,34 +2,36 @@ import {assert} from 'chai'
 import {shallowMount} from '@vue/test-utils'
 import TagList from 'components/TagList'
 
-it('has default css classes', function () {
-  const wrapper = shallowMount(TagList, {
-    propsData: {
-      tags: [{id: 1, name: 'a'}],
-    },
+describe('TagList', () => {
+  it('has default css classes', function () {
+    const wrapper = shallowMount(TagList, {
+      propsData: {
+        tags: [{id: 1, name: 'a'}],
+      },
+    })
+    assert.deepEqual(wrapper.classes(), ['tagList', 'tags'])
+    assert.deepEqual(wrapper.find('li').classes(), ['tagList-tag', 'tag', 'is-info', 'is-light'])
   })
-  assert.deepEqual(wrapper.classes(), ['tagList', 'tags'])
-  assert.deepEqual(wrapper.find('li').classes(), ['tagList-tag', 'tag', 'is-info', 'is-light'])
-})
 
-it('can override some of the default classes', function () {
-  const wrapper = shallowMount(TagList, {
-    propsData: {
-      tags: [{id: 2, name: 'b'}, [{id: 3, name: 'c'}]],
-      tagClasses: 'childClass',
-    },
+  it('can override some of the default classes', function () {
+    const wrapper = shallowMount(TagList, {
+      propsData: {
+        tags: [{id: 2, name: 'b'}, [{id: 3, name: 'c'}]],
+        tagClasses: 'childClass',
+      },
+    })
+    assert.deepEqual(wrapper.findAll('li').at(0).classes(), ['tagList-tag', 'tag', 'childClass'])
+    assert.deepEqual(wrapper.findAll('li').at(1).classes(), ['tagList-tag', 'tag', 'childClass'])
   })
-  assert.deepEqual(wrapper.findAll('li').at(0).classes(), ['tagList-tag', 'tag', 'childClass'])
-  assert.deepEqual(wrapper.findAll('li').at(1).classes(), ['tagList-tag', 'tag', 'childClass'])
-})
 
-it('renders empty if the tags are invalid', function () {
-  const nullWrapper = shallowMount(TagList, {
-    propsData: {tags: null},
+  it('renders empty if the tags are invalid', function () {
+    const nullWrapper = shallowMount(TagList, {
+      propsData: {tags: null},
+    })
+    const emptyWrapper = shallowMount(TagList, {propsData: {tags: []}})
+    const nullEmptyWrapper = shallowMount(TagList, {propsData: {tags: [null]}})
+    assert.isTrue(nullWrapper.isEmpty())
+    assert.isTrue(emptyWrapper.isEmpty())
+    assert.isTrue(nullEmptyWrapper.isEmpty())
   })
-  const emptyWrapper = shallowMount(TagList, {propsData: {tags: []}})
-  const nullEmptyWrapper = shallowMount(TagList, {propsData: {tags: [null]}})
-  assert.isTrue(nullWrapper.isEmpty())
-  assert.isTrue(emptyWrapper.isEmpty())
-  assert.isTrue(nullEmptyWrapper.isEmpty())
 })

--- a/spec/javascript/pages/browse/ContactIcons.spec.js
+++ b/spec/javascript/pages/browse/ContactIcons.spec.js
@@ -1,10 +1,11 @@
-import Vue from 'our_vue'
-import {shallowMount} from '@vue/test-utils'
+import {configure} from 'vue_config'
+import {createLocalVue, shallowMount} from '@vue/test-utils'
 import ContactIcons from 'pages/browse/ContactIcons'
 
 describe('ContactIcons', () => {
   it('generally works', function() {
     const wrapper = shallowMount(ContactIcons, {
+      localVue: configure(createLocalVue()),
       propsData: { contactTypes: [{id: 1, name: "email"}, {id: 2, name: "text"},{id: 3, name: "call"}]}
     })
     assert.exists(wrapper.find('b-icon-stub[aria-label=email][icon=envelope]').text())

--- a/spec/javascript/pages/browse/ContactIcons.spec.js
+++ b/spec/javascript/pages/browse/ContactIcons.spec.js
@@ -2,10 +2,12 @@ import Vue from 'our_vue'
 import {shallowMount} from '@vue/test-utils'
 import ContactIcons from 'pages/browse/ContactIcons'
 
-it('generally works', function() {
-  const wrapper = shallowMount(ContactIcons, {
-    propsData: { contactTypes: [{id: 1, name: "email"}, {id: 2, name: "text"},{id: 3, name: "call"}]}
+describe('ContactIcons', () => {
+  it('generally works', function() {
+    const wrapper = shallowMount(ContactIcons, {
+      propsData: { contactTypes: [{id: 1, name: "email"}, {id: 2, name: "text"},{id: 3, name: "call"}]}
+    })
+    assert.exists(wrapper.find('b-icon-stub[aria-label=email][icon=envelope]').text())
+    assert.exists(wrapper.find('b-icon-stub[aria-label=call][icon=phone]').text())
   })
-  assert.exists(wrapper.find('b-icon-stub[aria-label=email][icon=envelope]').text())
-  assert.exists(wrapper.find('b-icon-stub[aria-label=call][icon=phone]').text())
 })

--- a/spec/javascript/pages/browse/ListBrowser.spec.js
+++ b/spec/javascript/pages/browse/ListBrowser.spec.js
@@ -3,11 +3,13 @@ import {mount} from '@vue/test-utils'
 import ListBrowser from 'pages/browse/ListBrowser'
 import testData from '../../../../lib/listings.json'
 
-it('works with reasonable data', function () {
-  const wrapper = mount(ListBrowser, {
-    propsData: {
-      contributions: testData.contributions,
-    },
+describe('ListBrowser', () => {
+  it('works with reasonable data', function () {
+    const wrapper = mount(ListBrowser, {
+      propsData: {
+        contributions: testData.contributions,
+      },
+    })
+    assert.match(wrapper.text(), /look after my kid/i)
   })
-  assert.match(wrapper.text(), /look after my kid/i)
 })

--- a/spec/javascript/pages/browse/TileBrowser.spec.js
+++ b/spec/javascript/pages/browse/TileBrowser.spec.js
@@ -2,13 +2,15 @@ import {assert} from 'chai'
 import {mount} from '@vue/test-utils'
 import TileBrowser from 'pages/browse/ListBrowser'
 
-it('works with reasonable data', function () {
-  const testData = require('../../../../lib/listings.json')
+describe('TileBrowser', () => {
+  it('works with reasonable data', function () {
+    const testData = require('../../../../lib/listings.json')
 
-  const wrapper = mount(TileBrowser, {
-    propsData: {
-      contributions: testData.contributions,
-    },
+    const wrapper = mount(TileBrowser, {
+      propsData: {
+        contributions: testData.contributions,
+      },
+    })
+    assert.match(wrapper.text(), /look after my kid/i)
   })
-  assert.match(wrapper.text(), /look after my kid/i)
 })


### PR DESCRIPTION
1. 0e8085f : Eliminate Vue warning about duplicate keys when running specs
1. a039955 : Ensure all specs have a top-level describe block to help with output grouping
1. 4352e79: Rework vue configuration so it can be safely reused in specs without polluting a shared global Vue instance between specs.

Note: the diffs from number #2 above are mostly just whitespace, so i recommend ignoring whitespace changes on review.