### PR TITLE
First draft of using interactors for nested forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,50 +3,37 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.0'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
 
 # This should after rails but before any gems that might require it
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 
-# Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
-# Use Puma as the app server
-gem 'puma', '~> 4.1'
-# Use SCSS for stylesheets
-gem 'sass-rails', '>= 6'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 4.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 # gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.7'
-
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
-gem 'devise'
-gem 'reform-rails'
-gem 'simple_form'
-
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.2', require: false
-
+gem 'active_interaction'
 gem 'acts-as-taggable-array-on'
-
-# support translations on more than one model
+gem 'bootsnap', '>= 1.4.2', require: false
+gem 'devise'
+gem 'jbuilder', '~> 2.7'
 gem 'mobility', '~> 0.8.9'
-
-# email and sms
+gem 'pg', '>= 0.18', '< 2.0'
+gem 'puma', '~> 4.1'
+gem 'reform-rails'
+gem 'sass-rails', '>= 6'
 gem 'sendgrid-ruby'
+gem 'simple_form'
+gem 'webpacker', '~> 4.0'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'binding_of_caller'
   gem 'factory_bot_rails'
@@ -66,13 +53,9 @@ group :development do
   gem 'annotate'
   gem 'guard-rspec', require: false
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-commands-rspec'
+  gem 'spring-commands-rspec', require: false
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.0'
-
+gem 'rake'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
 
 # This should after rails but before any gems that might require it

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_interaction (3.8.2)
+      activemodel (>= 4, < 7)
     activejob (6.0.2.2)
       activesupport (= 6.0.2.2)
       globalid (>= 0.3.6)
@@ -293,6 +295,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_interaction
   acts-as-taggable-array-on
   annotate
   binding_of_caller
@@ -320,7 +323,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
   web-console (>= 3.3.0)
   webpacker (~> 4.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
+  rake
   reform-rails
   rspec-rails
   rspec_junit_formatter

--- a/Guardfile
+++ b/Guardfile
@@ -25,7 +25,7 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: "RUBYOPT='-W:no-deprecated' bin/rspec -f doc" do
+guard :rspec, cmd: "RUBYOPT='-W:no-deprecated' bin/spring rspec -f doc --no-profile" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/app/interactors/base_interactor.rb
+++ b/app/interactors/base_interactor.rb
@@ -1,0 +1,20 @@
+class BaseInteractor < ActiveInteraction::Base
+  def merging_errors(in_transaction: true)
+    block = -> do
+      object = yield
+
+      unless object&.errors.empty?
+        errors.merge! object.errors
+        raise ActiveRecord::Rollback if in_transaction
+      end
+
+      object
+    end
+
+    if in_transaction
+      ApplicationRecord.transaction(&block)
+    else
+      block.call
+    end
+  end
+end

--- a/app/interactors/save_listing.rb
+++ b/app/interactors/save_listing.rb
@@ -1,4 +1,4 @@
-class SaveListing < ActiveInteraction::Base
+class SaveListing < BaseInteractor
   record :service_area
   string :type
 
@@ -7,17 +7,9 @@ class SaveListing < ActiveInteraction::Base
   # todo: add other fields here and in nested interactors
 
   def execute
-    Listing.transaction do
+    merging_errors(in_transaction: true) do
       person_record = compose SavePerson, person
-
-      listing = Listing.create inputs.merge person: person_record
-
-      unless listing.valid?
-        errors.merge! listing.errors
-        raise ActiveRecord::Rollback
-      end
-
-      listing
+      Listing.create inputs.merge person: person_record
     end
   end
 end

--- a/app/interactors/save_listing.rb
+++ b/app/interactors/save_listing.rb
@@ -1,0 +1,23 @@
+class SaveListing < ActiveInteraction::Base
+  record :service_area
+  string :type
+
+  hash :person, strip: false
+
+  # todo: add other fields here and in nested interactors
+
+  def execute
+    Listing.transaction do
+      person_record = compose SavePerson, person
+
+      listing = Listing.create inputs.merge person: person_record
+
+      unless listing.valid?
+        errors.merge! listing.errors
+        raise ActiveRecord::Rollback
+      end
+
+      listing
+    end
+  end
+end

--- a/app/interactors/save_location.rb
+++ b/app/interactors/save_location.rb
@@ -1,0 +1,15 @@
+class SaveLocation < ActiveInteraction::Base
+  integer :id, default: nil
+  string :city
+  string :state
+
+  def execute
+    location = id? ?
+      Location.update(id, inputs) :
+      Location.create(inputs)
+
+    errors.merge! location.errors
+
+    location
+  end
+end

--- a/app/interactors/save_location.rb
+++ b/app/interactors/save_location.rb
@@ -1,15 +1,15 @@
-class SaveLocation < ActiveInteraction::Base
+class SaveLocation < BaseInteractor
   integer :id, default: nil
   string :city
   string :state
 
   def execute
-    location = id? ?
-      Location.update(id, inputs) :
-      Location.create(inputs)
-
-    errors.merge! location.errors
-
-    location
+    merging_errors do
+      if id?
+        Location.update(id, inputs)
+      else
+        Location.create(inputs)
+      end
+    end
   end
 end

--- a/app/interactors/save_person.rb
+++ b/app/interactors/save_person.rb
@@ -1,0 +1,33 @@
+class SavePerson < ActiveInteraction::Base
+  integer :id, default: nil
+  string :preferred_contact_method  # todo: string?
+  string :email
+
+  hash :location, strip: false
+
+  def execute
+    ensure_location_id_provided_if_existing_person!
+
+    Person.transaction do
+      location_record = compose SaveLocation, location
+      person_params = inputs.merge location: location_record
+
+      person = id? ?
+        Person.update(id, person_params) :
+        Person.create(person_params)
+
+      unless person.valid?
+        errors.merge! person.errors
+        raise ActiveRecord::Rollback
+      end
+
+      person
+    end
+  end
+
+  private
+
+    def ensure_location_id_provided_if_existing_person!
+      fail 'Missing location.id param attempting to update existing person' if id? && location[:id].blank?
+    end
+end

--- a/spec/interactors/save_listing_spec.rb
+++ b/spec/interactors/save_listing_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe SaveListing do
+  let(:service_area)    { create :service_area }
+  subject(:interaction) { SaveListing.run params }
+
+  describe 'validation' do
+    let(:params) {{
+      type: '',  # only Listing field with validation
+      service_area: service_area.id,
+      person: {
+        preferred_contact_method: 'email',
+        email: 'we@together.coop',
+        location: {
+          city: 'Lansing',
+          state: 'MI',
+        },
+      },
+    }}
+
+    it { is_expected.to be_invalid }
+
+    it 'does not create any records' do
+      expect { interaction }
+        .to  change(Listing,  :count).by(0)
+        .and change(Person,   :count).by(0)
+        .and change(Location, :count).by(0)
+    end
+
+    it 'gathers errors from nested objects' do
+      expect(interaction.errors.full_messages).to eq ["Type can't be blank"]
+    end
+  end
+end
+

--- a/spec/interactors/save_person_spec.rb
+++ b/spec/interactors/save_person_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe SavePerson do
+  let(:current_location) { create :location, city: 'flint' }
+  let(:current_person)   { create :person, location: current_location }
+
+  let(:params) {{
+    id: current_person&.id,
+    preferred_contact_method: 'email',
+    email: 'we@together.coop',
+    location: {
+      id: current_location&.id,
+      city: '',
+      state: 'DC', # statehood now!
+    },
+  }}
+
+  let(:interaction) { SavePerson.run params }
+  let(:person)      { interaction.result }
+
+  describe 'modification' do
+    it 'updates the current person and associated location' do
+      expect(person).to eq(current_person.reload)
+      expect(person.location).to eq current_location.reload
+    end
+
+    it 'allows for existing fields to be nullified' do
+      expect(person.location.city).to be_empty
+    end
+
+    context 'when params include a person.id but no location.id' do
+      let(:current_location) { nil }
+
+      it 'fails' do
+        expect { interaction }.to raise_error(/Missing location.id/)
+      end
+    end
+  end
+
+  describe 'creation' do
+    let(:current_person)   { nil }
+    let(:current_location) { nil }
+
+    it 'creates a person' do
+      expect(person).to be_persisted
+    end
+
+    it 'creates a nested location' do
+      expect(person.location).to be_persisted
+      expect(person.location.state).to eq 'DC'
+    end
+
+    context 'with invalid location params' do
+      before { params[:location][:state] = '' }
+
+      it 'makes the parent interaction invalid' do
+        expect(interaction).to be_invalid
+      end
+
+      it 'does not create either record' do
+        expect { interaction }
+          .to  change(Person, :count).by(0)
+          .and change(Location, :count).by(0)
+      end
+
+      it 'promotes nested errors' do
+        expect(interaction.errors.full_messages).to eq ["State can't be blank"]
+      end
+    end
+
+    context 'with invalid person params' do
+      before { params[:email] = '' }
+
+      it 'does not create either record' do
+        expect { interaction }
+          .to  change(Person, :count).by(0)
+          .and change(Location, :count).by(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Demonstrates using [ActiveInteraction](https://github.com/AaronLasseigne/active_interaction#rails) gem to help manage nested models involved in creating a listing: `Listing -> Person -> Location`.

It may be easier to review each of the two substantive commits separately, because the last one introduces a further abstraction on top of the gem.

While `compose` helps with calling one interactor from another, it doesn't handle two things that are important when dealing with nested forms:
1. merging errors from the child object into the parent
2. rolling back child records if parent records later fail
I've introduced the `merging_errors` method to remove the duplication involved with handling those considerations.

Note: i haven't defined all the necessary fields for any of these models. Just the minimum required to get it working and also test validation/errors.

There's more we could do with the gem. In particular, it supports ActiveModel validations at the interaction layer. I do prefer validations in that layer, but i'm hesitant to do this across the board because many controllers aren't complex enough to need an Interactor.