### PR TITLE
Add delete button to view_footer_buttons shared partial

### DIFF
--- a/app/views/layouts/_view_footer_buttons.html.erb
+++ b/app/views/layouts/_view_footer_buttons.html.erb
@@ -11,11 +11,18 @@
 <% submit_button_suffix ||= " index" %>
 
 <% cancel_button ||= link_to("Cancel and go to index", "/" + controller_name,
-                             class: "button mt-1 is-default") %>
+                             class: "button mt-1 is-outlined") %>
+
+<% delete_button ||= link_to("Delete",
+                             polymorphic_url(f.object),
+                             method: :delete,
+                             confirm: "Are you sure you want to delete this record?",
+                             class: "button mt-1 is-danger is-outlined") if f.object.id.present? %>
 
 <div class="form-actions">
   <% "<hr>".html_safe if top_divider %>
   <%= extra_form_button_1 %>
+  <%= delete_button %>
   <%= cancel_button %>
   <%= f.button :submit,
                "#{submit_button_prefix.to_s +


### PR DESCRIPTION
- Generate a delete_button if not passed in to `view_footer_buttons` partial (this is called by all forms)
- Allows you to call the partial and pass in `delete_button: ""` to NOT show a delete button (we need this for system_settings)