### PR TITLE
Improve circleci bundle install error messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@ commands:
             - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
       - run:
           name: "Bundle Install"
-          command: bin/bundle install --path=.bundle
+          command: |
+            set -euxo pipefail
+            bundle config set frozen 'true'
+            bin/bundle install --path=.bundle
       - save_cache:
           key: bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
This helps with troubleshooting Circle CI problems when the Gemfile and Gemfile.lock don't mach. Before this change, you would only see a failed step once the `ruby_tests` job started to run and the error for that failed step would me misleading as to the cause of the problem.

With this change, the error will show up in the `bundle_install` step, and will be more explicit about what the discrepancy is.

Here is a screenshot of what that more helpful error will look like:


<img width="728" alt="Screen Shot 2020-05-07 at 4 01 08 PM" src="https://user-images.githubusercontent.com/3620291/81339379-10c65800-907c-11ea-8d60-bf91043bcedb.png">