### PR TITLE
ContactMethod model

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,6 +10,7 @@ class PeopleController < ApplicationController
 
   def new
     @person = Person.new
+    set_form_dropdowns
   end
 
   def edit
@@ -59,7 +60,7 @@ class PeopleController < ApplicationController
 
     def set_form_dropdowns
       @system_locales = SystemLocale.where(publish_in_dropdowns: true).pluck(:locale_name, :id)
-      @preferred_contact_methods = Person::PREFERRED_CONTACT_METHODS
+      @preferred_contact_methods = ContactMethod.enabled
     end
 
     def person_params

--- a/app/interactors/save_person.rb
+++ b/app/interactors/save_person.rb
@@ -1,9 +1,8 @@
 class SavePerson < BaseInteractor
   integer :id, default: nil
-  string :preferred_contact_method  # todo: string?
-  string :email
-
-  hash :location, strip: false
+  record  :preferred_contact_method, class: 'ContactMethod'
+  string  :email
+  hash    :location, strip: false
 
   def execute
     ensure_location_id_provided_if_existing_person!

--- a/app/javascript/components/AuthTokenInput.vue
+++ b/app/javascript/components/AuthTokenInput.vue
@@ -1,0 +1,12 @@
+<template>
+  <input type="hidden" name="authenticity_token" :value="authenticityToken" />
+</template>
+
+<script>
+export default {
+  created: function() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')
+    this.authenticityToken = csrfToken ? csrfToken.content : null
+  },
+}
+</script>

--- a/app/javascript/components/DeleteButton.vue
+++ b/app/javascript/components/DeleteButton.vue
@@ -1,7 +1,7 @@
 <template>
   <form :action="action" method="post">
+    <AuthTokenInput />
     <input type="hidden" name="_method" value="delete" />
-    <input type="hidden" name="authenticity_token" :value="authenticityToken" />
     <button type="submit" class="button is-outlined">
       <slot />
     </button>
@@ -9,7 +9,10 @@
 </template>
 
 <script>
+import AuthTokenInput from './AuthTokenInput'
+
 export default {
+  components: {AuthTokenInput},
   props: {
     action: String,
   },

--- a/app/javascript/components/NavBar.vue
+++ b/app/javascript/components/NavBar.vue
@@ -30,7 +30,7 @@
 
 <script>
 import logo from 'images/logo.png'
-import DeleteButton from 'components/DeleteButton'
+import DeleteButton from './DeleteButton'
 
 export default {
   props: {

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -1,0 +1,3 @@
+class ContactMethod < ApplicationRecord
+  scope :enabled, -> { where enabled: true }
+end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -9,7 +9,7 @@
     </div>
 
     <div class="field is-grouped">
-      <%= f.input :preferred_contact_method, as: :select, collection: @preferred_contact_methods %>
+      <%= f.input :preferred_contact_method, as: :select, collection: @preferred_contact_methods, label_method: :name, value_method: :id %>
       <%= f.input :preferred_contact_timeframe %>
     </div>
 

--- a/db/migrate/20200509052637_create_contact_methods.rb
+++ b/db/migrate/20200509052637_create_contact_methods.rb
@@ -1,0 +1,11 @@
+class CreateContactMethods < ActiveRecord::Migration[6.0]
+  def change
+    create_table :contact_methods do |t|
+      t.string :name
+      t.string :field
+      t.boolean :enabled
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200509054235_change_person_preferred_contact_method_to_reference.rb
+++ b/db/migrate/20200509054235_change_person_preferred_contact_method_to_reference.rb
@@ -1,0 +1,6 @@
+class ChangePersonPreferredContactMethodToReference < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :people, :preferred_contact_method, :integer
+    add_column :people, :preferred_contact_method_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_09_052637) do
+ActiveRecord::Schema.define(version: 2020_05_09_054235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,7 +228,6 @@ ActiveRecord::Schema.define(version: 2020_05_09_052637) do
     t.string "email"
     t.string "phone_2"
     t.string "email_2"
-    t.string "preferred_contact_method"
     t.string "preferred_contact_timeframe"
     t.text "skills"
     t.text "notes"
@@ -240,6 +239,7 @@ ActiveRecord::Schema.define(version: 2020_05_09_052637) do
     t.string "preferred_locale", default: "en", null: false
     t.integer "monthly_matches_max", default: 0
     t.float "monthly_donation_amount_max", default: 0.0
+    t.integer "preferred_contact_method_id"
     t.index ["location_id"], name: "index_people_on_location_id"
     t.index ["service_area_id"], name: "index_people_on_service_area_id"
     t.index ["user_id"], name: "index_people_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_194010) do
+ActiveRecord::Schema.define(version: 2020_05_09_052637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,14 @@ ActiveRecord::Schema.define(version: 2020_05_08_194010) do
     t.index ["organization_id"], name: "index_community_resources_on_organization_id"
     t.index ["service_area_id"], name: "index_community_resources_on_service_area_id"
     t.index ["tags"], name: "index_community_resources_on_tags", using: :gin
+  end
+
+  create_table "contact_methods", force: :cascade do |t|
+    t.string "name"
+    t.string "field"
+    t.boolean "enabled"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "custom_form_questions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,4 +31,8 @@ locales.each do |locale, locale_name|
   SystemLocale.where(locale: locale).first_or_create!(locale_name: locale_name)
 end
 
+[['Call', 'phone'], ['Text', 'phone'], ['Email', 'email'], ['WhatsApp', 'phone']].each do |(name, field)|
+  ContactMethod.exists?(name: name) || ContactMethod.create!(name: name, field: field, enabled: true)
+end
+
 puts "completed seeds.rb"

--- a/spec/factories/contact_methods.rb
+++ b/spec/factories/contact_methods.rb
@@ -1,7 +1,17 @@
 FactoryBot.define do
-  factory :contact_method do
+  factory :contact_method, aliases: [:contact_method_call] do
     name    { 'Call' }
     field   { 'phone' }
     enabled { true }
+
+    factory :contact_method_text do
+      name  { 'Text' }
+      field { 'phone' }
+    end
+
+    factory :contact_method_email do
+      name  { 'Email' }
+      field { 'email' }
+    end
   end
 end

--- a/spec/factories/contact_methods.rb
+++ b/spec/factories/contact_methods.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :contact_method do
+    name    { 'Call' }
+    field   { 'phone' }
+    enabled { true }
+  end
+end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :person do
     first_name { Faker::Name.name }
     last_name { Faker::Name.name }
-    preferred_contact_method { "email" }
     email { Faker::Internet.email }
+    preferred_contact_method { association :contact_method_email }
 
     trait :with_email do
       preferred_contact_method { "email" }
@@ -11,7 +11,7 @@ FactoryBot.define do
     end
 
     trait :with_phone do
-      preferred_contact_method { "phone" }
+      preferred_contact_method { association :contact_method_phone }
       phone { Faker::PhoneNumber.phone_number }
     end
 

--- a/spec/interactors/save_listing_spec.rb
+++ b/spec/interactors/save_listing_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SaveListing do
   let(:service_area)    { create :service_area }
+  let(:contact_method)  { create :contact_method_email }
   subject(:interaction) { SaveListing.run params }
 
   describe 'validation' do
@@ -9,7 +10,7 @@ RSpec.describe SaveListing do
       type: '',  # only Listing field with validation
       service_area: service_area.id,
       person: {
-        preferred_contact_method: 'email',
+        preferred_contact_method: contact_method.id,
         email: 'we@together.coop',
         location: {
           city: 'Lansing',

--- a/spec/interactors/save_person_spec.rb
+++ b/spec/interactors/save_person_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe SavePerson do
+  let(:contact_method)   { create :contact_method_email }
   let(:current_location) { create :location, city: 'flint' }
   let(:current_person)   { create :person, location: current_location }
 
   let(:params) {{
     id: current_person&.id,
-    preferred_contact_method: 'email',
+    preferred_contact_method: contact_method.id,
     email: 'we@together.coop',
     location: {
       id: current_location&.id,

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  describe 'preferred_contact_method validation' do
+    let(:contact_method) { build :contact_method, name: 'Text', field: 'phone' }
+
+    subject(:person) { build :person, preferred_contact_method: contact_method }
+
+    context 'when the preferred method field is provided' do
+      before { person.phone = '123 456 1234' }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'when the preferred method field is missing' do
+      before { person.phone = nil }
+
+      it { is_expected.not_to be_valid }
+
+      it 'generates an error on the correct field' do
+        person.valid?
+        expect(person.errors.messages).to eq({phone: ["can't be blank"]})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactors 'contact methods' into its own table-backed model.
Motivations:
1. I was finding that i needed additional data for each contact method, such as the name of the corresponding field, and label (though i ended up getting that from `i18n` instead).
1. I could see an settings page where a system admin enables/disables the available contact methods and adds their own ones.