### PR TITLE
Add back in some view specs & some cleanup

### DIFF
--- a/app/views/software_feedbacks/edit.html.erb
+++ b/app/views/software_feedbacks/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render "layouts/view_header", resource: @submission %>
+<%= render "layouts/view_header", resource: @software_feedbacks %>

--- a/app/views/software_feedbacks/index.html.erb
+++ b/app/views/software_feedbacks/index.html.erb
@@ -2,36 +2,36 @@
 
 <table class="table table-hover table-curved table-condensed">
   <thead>
-  <tr>
-          <th>Created by</th>
-          <th>Feedback type</th>
-          <th>Module name</th>
-          <th>Page url</th>
-          <th>Name</th>
-          <th>Urgency</th>
-          <th>Urgency order</th>
-          <th>Notes</th>
-          <th>Completed</th>
-          <th>Completed at</th>
-        <th>Edit</th>
-  </tr>
+    <tr>
+      <th>Created by</th>
+      <th>Feedback type</th>
+      <th>Module name</th>
+      <th>Page url</th>
+      <th>Name</th>
+      <th>Urgency</th>
+      <th>Urgency order</th>
+      <th>Notes</th>
+      <th>Completed</th>
+      <th>Completed at</th>
+      <th>Edit</th>
+    </tr>
   </thead>
 
   <tbody>
-  <% @software_feedbacks.each do |software_feedback| %>
-    <tr>
-              <td><%= software_feedback.created_by_id %></td>
-              <td><%= software_feedback.feedback_type %></td>
-              <td><%= software_feedback.module_name %></td>
-              <td><%= software_feedback.page_url %></td>
-              <td><%= software_feedback.name %></td>
-              <td><%= software_feedback.urgency %></td>
-              <td><%= software_feedback.urgency_order %></td>
-              <td><%= software_feedback.notes %></td>
-              <td><%= software_feedback.completed %></td>
-              <td><%= software_feedback.completed_at %></td>
-            <td><%= link_to 'Edit', edit_software_feedback_path(software_feedback) %></td>
-    </tr>
-  <% end %>
+    <% @software_feedbacks.each do |software_feedback| %>
+      <tr>
+        <td><%= software_feedback.created_by&.name %></td>
+        <td><%= software_feedback.feedback_type %></td>
+        <td><%= software_feedback.module_name %></td>
+        <td><%= software_feedback.page_url %></td>
+        <td><%= software_feedback.name %></td>
+        <td><%= software_feedback.urgency %></td>
+        <td><%= software_feedback.urgency_order %></td>
+        <td><%= software_feedback.notes %></td>
+        <td><%= software_feedback.completed %></td>
+        <td><%= software_feedback.completed_at %></td>
+        <td><%= edit_button(software_feedback) %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/spec/factories/software_feedbacks.rb
+++ b/spec/factories/software_feedbacks.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     urgency_order { 1 }
     notes { "MyString" }
     completed { false }
-    completed_at { "2020-05-08 15:40:10" }
+    completed_at { Time.now }
   end
 end

--- a/spec/views/software_feedbacks/edit.html.erb_spec.rb
+++ b/spec/views/software_feedbacks/edit.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "software_feedbacks/edit", type: :view do
+  before(:each) do
+    @software_feedback = assign(:software_feedback, SoftwareFeedback.create!(
+      created_by: nil,
+      feedback_type: "MyString",
+      module_name: "MyString",
+      page_url: "MyString",
+      name: "MyString",
+      urgency: "MyString",
+      urgency_order: 1,
+      notes: "MyString",
+      completed: false
+    ))
+  end
+
+  it "renders the edit software_feedback form" do
+    render
+
+    assert_select "form[action=?][method=?]", software_feedback_path(@software_feedback), "post" do
+
+      assert_select "select[name=?]", "software_feedback[created_by_id]"
+
+      assert_select "input[name=?]", "software_feedback[feedback_type]"
+
+      assert_select "input[name=?]", "software_feedback[module_name]"
+
+      assert_select "input[name=?]", "software_feedback[page_url]"
+
+      assert_select "input[name=?]", "software_feedback[name]"
+
+      assert_select "input[name=?]", "software_feedback[urgency]"
+
+      assert_select "input[name=?]", "software_feedback[urgency_order]"
+
+      assert_select "input[name=?]", "software_feedback[notes]"
+
+      assert_select "input[name=?]", "software_feedback[completed]"
+    end
+  end
+end

--- a/spec/views/software_feedbacks/index.html.erb_spec.rb
+++ b/spec/views/software_feedbacks/index.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "software_feedbacks/index", type: :view do
+  let(:user) { create(:user) }
+  before(:each) do
+    assign(:software_feedbacks, [
+      create(:software_feedback,
+        created_by: user,
+      ),
+      create(:software_feedback,
+        created_by: user,
+      )
+    ])
+  end
+
+  it "renders a list of software_feedbacks" do
+    render
+    assert_select "tr>td", text: user&.name, count: 2
+  end
+end

--- a/spec/views/software_feedbacks/new.html.erb_spec.rb
+++ b/spec/views/software_feedbacks/new.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "software_feedbacks/new", type: :view do
+  before(:each) do
+    assign(:software_feedback, SoftwareFeedback.new(
+      created_by: nil,
+      feedback_type: "MyString",
+      module_name: "MyString",
+      page_url: "MyString",
+      name: "MyString",
+      urgency: "MyString",
+      urgency_order: 1,
+      notes: "MyString",
+      completed: false
+    ))
+  end
+
+  it "renders new software_feedback form" do
+    render
+
+    # assert_select "form[action=?][method=?]", software_feedbacks_path, "post" do
+
+      assert_select "select[name=?]", "software_feedback[created_by_id]"
+
+      assert_select "input[name=?]", "software_feedback[feedback_type]"
+
+      assert_select "input[name=?]", "software_feedback[module_name]"
+
+      assert_select "input[name=?]", "software_feedback[page_url]"
+
+      assert_select "input[name=?]", "software_feedback[name]"
+
+      assert_select "input[name=?]", "software_feedback[urgency]"
+
+      assert_select "input[name=?]", "software_feedback[urgency_order]"
+
+      assert_select "input[name=?]", "software_feedback[notes]"
+
+      assert_select "input[name=?]", "software_feedback[completed]"
+    # end
+  end
+end

--- a/spec/views/software_feedbacks/show.html.erb_spec.rb
+++ b/spec/views/software_feedbacks/show.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe "software_feedbacks/show", type: :view do
+  before(:each) do
+    @software_feedback = assign(:software_feedback, SoftwareFeedback.create!(
+      created_by: nil,
+      feedback_type: "Feedback Type",
+      module_name: "Module Name",
+      page_url: "Page Url",
+      name: "Name",
+      urgency: "Urgency",
+      urgency_order: 2,
+      notes: "Notes",
+      completed: false
+    ))
+  end
+
+  it "renders attributes in <p>" do
+    render
+    expect(rendered).to match(//)
+    expect(rendered).to match(/Feedback Type/)
+    expect(rendered).to match(/Module Name/)
+    expect(rendered).to match(/Page Url/)
+    expect(rendered).to match(/Name/)
+    expect(rendered).to match(/Urgency/)
+    expect(rendered).to match(/2/)
+    expect(rendered).to match(/Notes/)
+    expect(rendered).to match(/false/)
+  end
+end

--- a/spec/views/submissions/edit.html.erb_spec.rb
+++ b/spec/views/submissions/edit.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "submissions/edit", type: :view do
+  let(:person) { create(:person) }
+  let(:service_area) { create(:service_area) }
+  before(:each) do
+    @submission = create(:submission,
+                         person: person,
+                         service_area: service_area,
+                         form_name: "MyString",
+                         body: "MyText"
+    )
+  end
+
+  it "renders the edit submission form" do
+    render
+
+    assert_select "form[action=?][method=?]", submission_path(@submission), "post" do
+
+      assert_select "select[name=?]", "submission[person_id]"
+
+      assert_select "select[name=?]", "submission[service_area_id]"
+
+      assert_select "input[name=?]", "submission[form_name]"
+    end
+  end
+end

--- a/spec/views/submissions/index.html.erb_spec.rb
+++ b/spec/views/submissions/index.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "submissions/index", type: :view do
+  let(:person) { create(:person) }
+  before(:each) do
+    assign(:submissions, [
+      create(:submission,
+             person: person,
+      ),
+      create(:submission,
+             person: person,
+      )
+    ])
+  end
+
+  it "renders a list of submissions" do
+    render
+
+    assert_select "tr>td", text: person&.name, count: 2
+  end
+end

--- a/spec/views/submissions/new.html.erb_spec.rb
+++ b/spec/views/submissions/new.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "submissions/new", type: :view do
+  let(:person) { create(:person) }
+  let(:service_area) { create(:service_area) }
+  before(:each) do
+    assign(:submission, create(:submission,
+                               person: person,
+                               service_area: service_area,
+                               form_name: "MyString",
+                               body: "MyText"
+    ))
+  end
+
+  it "renders new submission form" do
+    render
+
+    # assert_select "form[action=?][method=?]", submissions_path, "post" do
+
+      assert_select "select[name=?]", "submission[person_id]"
+
+      assert_select "select[name=?]", "submission[service_area_id]"
+
+      assert_select "input[name=?]", "submission[form_name]"
+    # end
+  end
+end

--- a/spec/views/submissions/show.html.erb_spec.rb
+++ b/spec/views/submissions/show.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "submissions/show", type: :view do
+  let(:person) { create(:person) }
+  let(:service_area) { create(:service_area) }
+  before(:each) do
+    @submission = create(:submission,
+                         person: person,
+                         service_area: service_area,
+                         form_name: "Form Name",
+                         body: "MyText"
+    )
+  end
+
+  it "renders attributes in <p>" do
+    render
+    expect(rendered).to match(//)
+    expect(rendered).to match(//)
+    expect(rendered).to match(/Form Name/)
+    expect(rendered).to match(/MyText/)
+  end
+end


### PR DESCRIPTION
- Now that the view_header and edit_button/show_button helpers handle test controller params,
  these can be added back in: spec/views/software_feedbacks && spec/views/submissions
- updated software_feedbacks factory to use Time.now vs frozen string for unique data
- fixed typo on software_feedbacks/edit
- changed indentation on sofware_feedbacks/index