### PR TITLE
Add ContributionsController, etc, (so we can move out of ListingsController)

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,0 +1,39 @@
+class ContributionsController < ApplicationController
+  before_action :set_contribution, only: [:show, :edit, :update, :destroy]
+
+  CONTRIBUTION_MODELS = { 'Ask' => Ask, 'Offer' => Offer }.freeze # TODO - add CommunityResource
+
+  def index
+    # TODO: these json fixtures are to be replaced with actual generators of data
+    sample_data = File.open('lib/listings.json') do |file|
+      JSON.load(file)
+    end
+    sample_filter_categories = File.open('lib/filterCategories.json') do |file|
+      JSON.load(file)
+    end
+    @contributions = sample_data["contributions"]
+    @filter_categories = sample_filter_categories
+  end
+
+  def allowed_params
+    @allowed_params ||= params.permit('contribution_type', 'format', 'Category' => {}, 'ServiceArea' => {})
+  end
+
+  def filter_params
+    return Hash.new unless allowed_params && allowed_params.to_h.any?
+    allowed_params.keys.intersection(['Category', 'ServiceArea']).each_with_object({}) do |model_name, data|
+      data[model_name.underscore] = allowed_params[model_name].keys
+    end
+  end
+
+  def contribution_type_params
+    type_list = allowed_params && allowed_params['contribution_type']
+    return unless type_list
+    type_list.split(',').map {|name| CONTRIBUTION_MODELS[name]}.compact
+  end
+
+  def contributions_for(parameters, models = CONTRIBUTION_MODELS.values)
+    models.map { |model| model.tagged_with(parameters) }.flatten
+  end
+
+end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -1,0 +1,3 @@
+class Contribution
+  # TODO - do we want to store some stuff here ?
+end

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -1,0 +1,14 @@
+<section class="section">
+  <div id="entry-point" />
+</section>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // TODO: remove public listings (this, entry point, component) once Browse is ready
+        // EntryPoints.publicListings('#public-listings')
+        EntryPoints.browse('#entry-point', {
+            contributions: <%= raw json_escape(@contributions.to_json) %>,
+            filterCategories: <%= raw json_escape(@filter_categories.to_json) %>
+        });
+    });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get "/announcements_list",       to: "public_pages#announcements",       as: "announcements_public"
   get "/community_resources_list", to: "public_pages#community_resources", as: "community_resources_public"
   get "/combined_form",            to: "public_pages#combined_form",       as: "combined_form_public"
-  get "/contributions",            to: "public_pages#contributions",       as: "contributions_public"
+  get "/contributions",            to: "public_pages#contributions",       as: "contributions_public" # TODO remove this
 
   resources :announcements
   resources :asks, only: [:index, :edit, :update, :new, :create]
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :communication_logs
   resources :community_resources
   resources :contact_methods
+  resources :contributions, only: [:index, :respond]
   resources :custom_form_questions
   resources :donations
   resources :feedbacks

--- a/spec/factories/contributions.rb
+++ b/spec/factories/contributions.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :contribution do
+  end
+end

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "/contributions", type: :request do
+  let(:valid_attributes) {{
+      location_attributes: {zip: "12345"},
+      tag_list: ["", "cash"],
+      # name: Faker::Name.name,
+      # email: Faker::Internet.email,
+      # phone: Faker::PhoneNumber.phone_number
+  }}
+
+  let(:invalid_attributes) {{
+      location_attributes: {zip: "12e45"},
+  }}
+
+  before { sign_in create(:user) }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      create(:listing)
+      get contributions_public_url
+      expect(response).to be_successful
+    end
+  end
+
+end


### PR DESCRIPTION
I started to stub out moving the `contributions` data to a ContributionsController vs doing it through the ListingsController (and redirected through PublicPagesController#contributions).

@h-m-m if any of this is helpful this week or next (or the one after that! :)), please feel free to use! :)