### PR TITLE
Rename smtp vars accordingly rather than sendgrid-specific

### DIFF
--- a/.env.ci.example
+++ b/.env.ci.example
@@ -4,16 +4,21 @@
 SYSTEM_APP_NAME=mutual-aid-app
 SYSTEM_EMAIL=mutualaidtesting@example.com
 SYSTEM_PASSWORD=testing123
+SYSTEM_HOST_NAME=localhost
 
 # DB hostname required for CircleCI. Feel free to override it in .env.test.local
 POSTGRES_HOST=localhost
-MUTUALAID_DATABASE_PASSWORD=testing123
+# POSTGRES_PASSWORD=
+# POSTGRES_USER= (for docker deployment)
+# POSTGRES_DB= (for docker deployment)
 
-# SendGrid api key
+# Email (recommend SendGrid) api key
+# SMTP_PORT=587
+SMTP_USERNAME=123
+SMTP_PASSWORD=123
+SMTP_FROM_EMAIL=mutualaidapptesting@example.com
+SMTP_ADDRESS=smtp.sendgrid.net
 SENDGRID_API_KEY=123
-SENDGRID_USERNAME=123
-SENDGRID_PASSWORD=123
-SENDGRID_FROM_EMAIL=mutualaidapptesting@example.com
 
 # (optional) override devise hours after which link expires (defaults to 6)
 HOURS_PASSWORD_RESET_LINK_EXPIRES_AFTER=8

--- a/.env.ci.example
+++ b/.env.ci.example
@@ -13,7 +13,7 @@ POSTGRES_HOST=localhost
 # POSTGRES_DB= (for docker deployment)
 
 # Email (recommend SendGrid) api key
-# SMTP_PORT=587
+SMTP_PORT=587
 SMTP_USERNAME=123
 SMTP_PASSWORD=123
 SMTP_FROM_EMAIL=mutualaidapptesting@example.com

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,13 +68,13 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.default :charset => "utf-8"
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: "#{ENV['SYSTEM_HOST_NAME']}" }
+  config.action_mailer.default_url_options = { host: ENV['SYSTEM_HOST_NAME'] }
   config.action_mailer.smtp_settings = {
-      address:              'smtp.sendgrid.net',
-      port:                 587,
-      domain:               "#{ENV['SYSTEM_HOST_NAME']}",
-      user_name:            ENV['SENDGRID_USERNAME'],
-      password:             ENV['SENDGRID_PASSWORD'],
+      address:              ENV['SMTP_ADDRESS'],
+      port:                 "#{ENV['SMTP_PORT'] || 587}".to_i,
+      domain:               ENV['SYSTEM_HOST_NAME'],
+      user_name:            ENV['SMTP_USERNAME'],
+      password:             ENV['SMTP_PASSWORD'],
       authentication:       'plain',
       enable_starttls_auto: true
   }


### PR DESCRIPTION
Change SENDGRID-specific ENV vars to SMTP bc some groups will not use SENDGRID 