### PR TITLE
update list contribution browser to be in line with latest changes

### DIFF
--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -3,15 +3,21 @@
     <h2 class="title">List view</h2>
     <table class="table table-hover table-curved table-condensed is-hoverable">
       <tr>
+        <th>Type</th>
         <th>Categories</th>
-        <th>Availability</th>
-        <th>Location</th>
+        <th>Service Area</th>
+        <th>Connect</th>
         <th>Details</th>
       </tr>
       <tr v-for="contribution in contributions" :key="contribution.id">
+        <td><MappedIconList :iconTypes="[{id: id, name: contribution.contribution_type}]" /></td>
         <td><TagList :tags="contribution.category_tags" /></td>
-        <td><TagList :tags="contribution.availability" tagClasses="is-light is-warning"/></td>
         <td><TagList :tags="[contribution.service_area]" /></td>
+        <td>
+          <MappedIconList :iconTypes="contribution.contact_types" />
+          <a :href="contribution.profile_path" class="button icon-list is-primary is-outlined">View Profile</a>
+          <a :href="contribution.respond_path" class="button icon-list is-primary is-outlined">Respond</a>
+        </td>
         <td>{{ contribution.title }}</td>
       </tr>
     </table>
@@ -20,6 +26,7 @@
 
 <script>
 import TagList from 'components/TagList'
+import MappedIconList from 'components/MappedIconList'
 
 export default {
   props: {
@@ -28,6 +35,7 @@ export default {
   },
   components: {
     TagList,
+    MappedIconList,
   },
 }
 </script>


### PR DESCRIPTION
## Notes
All the filtering from #236 works just fine here

Still would be nice if the site could remember whether you last used tile or list browse instead of forgetting every page load

## Screenshots
### Tablet breakpoint <img width="795" alt="Screen Shot 2020-05-14 at 4 58 31 PM" src="https://user-images.githubusercontent.com/3620291/81985971-07e9ff00-9605-11ea-9181-8e1531401b10.png">

### Largest breakpoint
<img width="1238" alt="Screen Shot 2020-05-14 at 5 11 22 PM" src="https://user-images.githubusercontent.com/3620291/81986527-f48b6380-9605-11ea-94de-3018d64c67ff.png">


