### PR TITLE
Change communication log fields

### DIFF
--- a/app/controllers/communication_logs_controller.rb
+++ b/app/controllers/communication_logs_controller.rb
@@ -60,11 +60,10 @@ class CommunicationLogsController < ApplicationController
           :match_id,
           :body,
           :created_by_id,
-          :delivery_channel,
+          :delivery_method_id,
           :delivery_status,
-          :from_type,
           :needs_follow_up,
-          :to_type,
+          :outbound,
           :sent_at,
           :subject,
       )

--- a/app/models/communication_log.rb
+++ b/app/models/communication_log.rb
@@ -1,16 +1,14 @@
 class CommunicationLog < ApplicationRecord
+  belongs_to :delivery_method, class_name: "ContactMethod", foreign_key: "delivery_method_id"
   belongs_to :person, optional: true
   belongs_to :match, optional: true
   belongs_to :created_by, optional: true, class_name: "User", foreign_key: "created_by_id"
 
   DEFAULT_DELIVERY_STATUS = "completed"
 
-  AUTO_DELIVERY_CHANNEL = "autoemail"
-  DELIVERY_CHANNELS = [AUTO_DELIVERY_CHANNEL, "email", "text", "call", "snailmail"]
-
-  def self.log_submission_email(email_object, delivery_status, submission, delivery_channel=nil, current_user=nil)
-    delivery_channel ||= AUTO_DELIVERY_CHANNEL
-    self.create!(delivery_channel: delivery_channel,
+  def self.log_submission_email(email_object, delivery_status, submission, delivery_method=nil, current_user=nil)
+    delivery_method ||= ContactMethod.autoemail(true).last
+    self.create!(delivery_method: delivery_method,
                  delivery_status: delivery_status,
                  person: submission.person,
                  sent_at: Time.now,
@@ -21,7 +19,7 @@ class CommunicationLog < ApplicationRecord
   end
 
   def name
-    "#{delivery_channel}: #{subject} #{created_at.strftime("%A, %B %d, %Y at %l:%M %P")}"
+    "#{delivery_method}: #{subject} #{created_at.strftime("%A, %B %d, %Y at %l:%M %P")}"
   end
 
 end

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -2,6 +2,8 @@ class ContactMethod < ApplicationRecord
   has_many :people, inverse_of: :preferred_contact_method, foreign_key: :preferred_contact_method_id, dependent: :restrict_with_error
 
   scope :enabled, -> { where enabled: true }
+  scope :autoemail, -> (boolean){ where( boolean ? arel_table[:name].lower.eq("autoemail") : arel_table[:name].lower.not_eq("autoemail") ) }
+
   scope :as_filter_types, -> { enabled.distinct(:name) }
 
   def label

--- a/app/views/communication_logs/_form.html.erb
+++ b/app/views/communication_logs/_form.html.erb
@@ -3,21 +3,23 @@
 
   <div class="form-inputs">
     <%= f.association :person %>
-    <%= f.association :match %>
-    <%= f.input :from_type %>
-    <%= f.input :to_type %>
+    <%= f.association :match, label: "Re: Match" %>
 
-    <%= f.input :needs_follow_up, as: :radio_buttons %>
+    <div class="field is-grouped">
+      <%= f.input :sent_at, label: "Time sent/received", default: Time.now, required: true %>
+      <%= f.input :outbound, as: :radio_buttons, checked: true %>
+    </div>
 
-    <%= f.input :sent_at %>
-
-    <%= f.input :delivery_channel, as: :select, collection: CommunicationLog::DELIVERY_CHANNELS %>
-    <%= f.input :delivery_status, default: CommunicationLog::DEFAULT_DELIVERY_STATUS %>
+    <div class="field is-grouped">
+      <%= f.association :delivery_method, required: true, collection: ContactMethod.all %>
+      <%= f.input :delivery_status, as: :select, required: true, collection: CommunicationLog::DELIVERY_STATUSES %>
+      <%= f.input :needs_follow_up, as: :radio_buttons %>
+    </div>
 
     <%= f.input :subject, as: :text, input_html: { rows: 1 } %>
 
     <hr>
-    <% if f.object.persisted? && f.object.delivery_channel == CommunicationLog::AUTO_DELIVERY_CHANNEL %>
+    <% if f.object.persisted? && f.object.delivery_method&.name == ContactMethod.autoemail(true).last.name %>
       <%= f.label :body, class: "label" %>
       <%= f.object.body&.html_safe || "-- Empty --" %>
     <% else %>

--- a/app/views/communication_logs/index.html.erb
+++ b/app/views/communication_logs/index.html.erb
@@ -4,7 +4,7 @@
   <table class="table table-hover table-curved table-condensed">
     <thead>
     <tr>
-      <th>Channel</th>
+      <th>Method</th>
       <th>Status</th>
       <th>Person</th>
       <th>Subject</th>
@@ -17,7 +17,7 @@
     <tbody>
     <% @communication_logs.each do |communication_log| %>
       <tr>
-        <td><%= communication_log.delivery_channel %></td>
+        <td><span class="<%= communication_log.delivery_method&.icon_class %>"></span></td>
         <td><%= communication_log.delivery_status %></td>
         <td><%= communication_log.person&.name %></td>
         <td><%= communication_log.subject %></td>

--- a/app/views/communication_logs/show.html.erb
+++ b/app/views/communication_logs/show.html.erb
@@ -7,8 +7,8 @@
   </p>
 
   <p>
-    <strong>Delivery channel:</strong>
-    <%= @communication_log.delivery_channel %>
+    <strong>Delivery method:</strong>
+    <%= @communication_log.delivery_method&.name %>
   </p>
 
   <p>

--- a/db/migrate/20200516190206_change_communication_log_fields.rb
+++ b/db/migrate/20200516190206_change_communication_log_fields.rb
@@ -1,0 +1,10 @@
+class ChangeCommunicationLogFields < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :communication_logs, :from_type, :string
+    remove_column :communication_logs, :to_type, :string
+    add_column :communication_logs, :outbound, :boolean, null: false, default: true, index: true
+
+    remove_column :communication_logs, :delivery_channel, :string
+    add_reference :communication_logs, :delivery_method, null: false, index: true, foreign_table_name: :contact_methods
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,9 +45,6 @@ ActiveRecord::Schema.define(version: 2020_05_16_190206) do
   create_table "communication_logs", force: :cascade do |t|
     t.bigint "person_id"
     t.bigint "match_id"
-    t.string "from_type"
-    t.string "to_type"
-    t.string "delivery_channel"
     t.datetime "sent_at"
     t.boolean "needs_follow_up", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -56,7 +53,10 @@ ActiveRecord::Schema.define(version: 2020_05_16_190206) do
     t.string "subject"
     t.bigint "created_by_id", default: 1, null: false
     t.string "body"
+    t.boolean "outbound", default: true, null: false
+    t.bigint "delivery_method_id", null: false
     t.index ["created_by_id"], name: "index_communication_logs_on_created_by_id"
+    t.index ["delivery_method_id"], name: "index_communication_logs_on_delivery_method_id"
     t.index ["match_id"], name: "index_communication_logs_on_match_id"
     t.index ["person_id"], name: "index_communication_logs_on_person_id"
   end


### PR DESCRIPTION
- Remove the from_type and to_type fields, that were dying on the vine
- Add outgoing boolean to distinguish whether the log is an incoming communication or outgoing
- Inherit from ContactMethod for delivery_method assn, since this was essentially duplicative w that data
- Add `autoemail` scope on ContacMethod to find methods that are/aren't system logs (autoemails)