### PR TITLE
Add system setting to mailer

### DIFF
--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -3,11 +3,12 @@ include ApplicationHelper
 
 class SubmissionMailer < ApplicationMailer
 
-  def new_submission_confirmation_email(submission)
+  def new_submission_confirmation_email(submission, system_setting=nil)
     @submission = submission
 
     current_organization = Organization.current_organization
     @organization_name = current_organization.name
+    @system_setting = system_setting || SystemSetting.first
 
     @form_name = @submission.form_name
     if @form_name.downcase.include?("ask")


### PR DESCRIPTION
Accept system_setting as an optional param in submission_mailer to conditionally send relevant email text.