### PR TITLE
Update datetime on contribution json to display better in the browser

### DIFF
--- a/app/blueprints/contribution_blueprint.rb
+++ b/app/blueprints/contribution_blueprint.rb
@@ -10,7 +10,7 @@ class ContributionBlueprint < Blueprinter::Base
   end
   fields :title, :description
   field :created_at do |contribution, _options|
-    contribution.created_at.to_formatted_s(:iso8601)
+    contribution.created_at.to_f * 1000 # Javascript wants miliseconds, not seconds
   end
   field :type, name: :contribution_type
   field :profile_path do |contribution, options|

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -29,7 +29,7 @@
           <small>Service area:</small> {{ service_area.name }}
         </div>
         <div class="has-text-grey-lighter">
-          <small>Submitted: <time :datetime="created_at">{{ created_at }}</time></small>
+          <small>Submitted: <time :datetime="createdAtDate.toISOString()">{{ createdAtDate.toLocaleDateString() }} {{ createdAtDate.toLocaleTimeString() }}</time></small>
         </div>
       </div>
     </div>
@@ -59,7 +59,7 @@ export default {
     service_area: {type: Object, default: null},
     title: String,
     description: String,
-    created_at: String,
+    created_at: Number,
     urgency: Object,
     contact_types: {type: Array, default: () => []},
     profile_path: String,
@@ -78,6 +78,9 @@ export default {
     urgencyColor() {
       return this.showUrgentIcon ? 'is-light is-warning' : ''
     },
+    createdAtDate() {
+      return new Date(this.created_at)
+    }
   },
 }
 </script>

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ContributionBlueprint do
                                # "availability" => [{"id" => 1, "name" => "AM"}],
                                # "publish_until" => "2021-10-11",
                                # "publish_until_humanized" => "this year",
-                               "created_at" => contribution.created_at.to_formatted_s(:iso8601),
+                               "created_at" => (contribution.created_at.to_f * 1000), # Javascript wants miliseconds, not seconds
                                'respond_path' => nil,
                                'profile_path' => nil,
                                'match_path' => nil,


### PR DESCRIPTION
### Summary

Resolves #331

### Screenshot

#### Before

<img width="211" alt="Screen Shot 2020-05-23 at 11 42 49 AM" src="https://user-images.githubusercontent.com/3620291/82734688-95ef7500-9cea-11ea-9e4c-9bf29316916d.png">

#### After
<img width="206" alt="Screen Shot 2020-05-23 at 12 00 51 PM" src="https://user-images.githubusercontent.com/3620291/82735157-90dff500-9ced-11ea-87f0-1811d109f445.png">

My local timezone is set to EDT, so the time conversion here is accurate. The time conversion occurs locally, in the browser

