### PR TITLE
Refactor browse filtering

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -3,10 +3,9 @@ class ContributionsController < ApplicationController
   before_action :set_contribution, only: [:respond]
 
   def index
-    @filter_types = FilterTypeBlueprint.render([Category, ServiceArea])
-    contribution_types = contribution_type_params
-    contribution_types ||= CONTRIBUTION_MODELS.values
-    @contributions = ContributionBlueprint.render(contributions_for(filter_params, contribution_types))
+    @filter_types = FilterTypeBlueprint.render([ContributionType, Category, ServiceArea, UrgencyLevel, ContactMethod])
+    filter = BrowseFilter.new(filter_params, self)
+    @contributions = ContributionBlueprint.render(filter.contributions, **filter.options)
     respond_to do |format|
       format.html
       format.json { render inline: @contributions }
@@ -24,32 +23,21 @@ class ContributionsController < ApplicationController
   def thank_you
   end
 
-  def allowed_params
-    @allowed_params ||= params.permit('contribution_type', 'format', 'Category' => {}, 'ServiceArea' => {})
-  end
+  private
 
   def filter_params
     return Hash.new unless allowed_params && allowed_params.to_h.any?
-    allowed_params.keys.intersection(['Category', 'ServiceArea']).each_with_object({}) do |model_name, data|
-      data[model_name.underscore] = allowed_params[model_name].keys
+    allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key}.tap do |hash|
+      hash.keys.each { |key| hash[key] = hash[key].keys}
     end
   end
 
-  def contribution_type_params
-    type_list = allowed_params && allowed_params['contribution_type']
-    return unless type_list
-    type_list.split(',').map {|name| CONTRIBUTION_MODELS[name]}.compact
+  def allowed_params
+    @allowed_params ||= params.permit(:format, **BrowseFilter::ALLOWED_PARAMS)
   end
-
-  def contributions_for(parameters, models = CONTRIBUTION_MODELS.values)
-    models.map { |model| model.filter_by(parameters) }.flatten
-  end
-
-  private
 
   def set_contribution
     type = params["contribution_type"]&.classify || "Ask"
     @contribution = Listing.where(type: type, id: params[:id]).first
   end
-
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -3,12 +3,8 @@ class ListingsController < ApplicationController
 
   def index
     @filter_types = FilterTypeBlueprint.render([ContributionType, Category, ServiceArea, UrgencyLevel, ContactMethod])
-    @contributions = ContributionBlueprint.render(
-      BrowseFilter.contributions_for(filter_params),
-      profile_path: ->(id) { person_path(id) },
-      respond_path: ->(id) { respond_contribution_path(id)},
-      match_path: ->(id) { Listing.find(id).ask? ? new_match_path(receiver_id: id) : new_match_path(provider_id: id)}
-    )
+    filter = BrowseFilter.new(filter_params, self)
+    @contributions = ContributionBlueprint.render(filter.contributions, **filter.options)
     respond_to do |format|
       format.html
       format.json { render inline: @contributions }

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -1,7 +1,7 @@
 # BrowseFilter code currently makes a lot of assumptions about the model coming in
 # I'm going to have to some lifting to make it accept other models
 # but at least all these changes will be isolated to this class
-module BrowseFilter
+class BrowseFilter
   FILTERS = {
     'ServiceArea' => ->(ids, scope) { scope.where(service_area: ids) },
     'ContactMethod' => ->(ids, scope) { scope.joins(:person).where(people: {preferred_contact_method: ids})},
@@ -21,18 +21,37 @@ module BrowseFilter
   end.freeze
   ALLOWED_MODEL_NAMES = ['Ask', 'Offer'].freeze
 
-  class << self
-    def contributions_for(parameters)
+  attr_reader :parameters, :context
+
+  def initialize(parameters, context = nil)
+    @parameters = parameters
+    @context = context
+  end
+
+  def contributions
+    @contributions ||= begin
       model_names = parameters.fetch('ContributionType', ALLOWED_MODEL_NAMES)
       models = ContributionType.where(name: model_names.intersection(ALLOWED_MODEL_NAMES)).map(&:model)
-      models.map { |model| filter_by(parameters, model) }.flatten
+      models.map { |model| filter(model) }.flatten
     end
+  end
 
-    def filter_by(conditions, model)
-      conditions.keys.reduce(model.all) do |scope, key|
-        filter = FILTERS.fetch(key, ->(_condition, s) {s})
-        filter.call(conditions[key], scope)
-      end
+  def options
+    return {} unless context
+
+    {
+      profile_path: ->(id) { context.person_path(id) },
+      respond_path: ->(id) { context.respond_contribution_path(id)},
+      match_path: ->(id) { Listing.find(id).type == "Ask" ? context.new_match_path(receiver_id: id) : context.new_match_path(provider_id: id)}
+    }
+  end
+
+  private
+
+  def filter(model)
+    parameters.keys.reduce(model.all) do |scope, key|
+      filter = FILTERS.fetch(key, ->(_condition, s) {s})
+      filter.call(parameters[key], scope)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   get "/about",                    to: "public_pages#about",               as: "about_public"
   get "/announcements_list",       to: "public_pages#announcements",       as: "announcements_public"
   get "/community_resources_list", to: "public_pages#community_resources", as: "community_resources_public"
-  get "/contributions",            to: "public_pages#contributions",       as: "contributions_public" # TODO remove this
+  # get "/contributions",            to: "public_pages#contributions",       as: "contributions_public" # TODO remove this
 
   resources :announcements
   resources :asks, only: [:index, :edit, :update, :new, :create]

--- a/spec/models/browse_filter_spec.rb
+++ b/spec/models/browse_filter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BrowseFilter do
     end
     expect(unmodified_scope).not_to receive(:where)
     all_urgency_level_ids = UrgencyLevel::TYPES.map(&:id)
-    BrowseFilter.contributions_for('UrgencyLevel' => all_urgency_level_ids)
+    BrowseFilter.new('UrgencyLevel' => all_urgency_level_ids).contributions
   end
 
   it 'will query for urgnecy levels if only one urgency level is checked' do
@@ -19,6 +19,6 @@ RSpec.describe BrowseFilter do
     end
     one_urgency_level_id = [UrgencyLevel::TYPES.sample.id]
     expect(used_scope).to receive(:where).with(urgency_level_id: one_urgency_level_id).exactly(ContributionType::TYPES.length).times
-    BrowseFilter.contributions_for('UrgencyLevel' => one_urgency_level_id)
+    BrowseFilter.new('UrgencyLevel' => one_urgency_level_id).contributions
   end
 end

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -18,10 +18,47 @@ RSpec.describe "/contributions", type: :request do
   describe "GET /index" do
     it "renders a successful response" do
       create(:listing)
-      get contributions_public_url
-      skip # TODO - get this working instead of listingscontroller
+      get contributions_url
       expect(response).to be_successful
     end
-  end
 
+    it 'allows asking for a specific subtype of listing' do
+      ask = create(:ask, title: 'this is the ask title')
+      offer = create(:offer, title: 'this is the offer title')
+      get contributions_url, params: {ContributionType: {'Ask' => 1}}
+      expect(response.body).to match(ask.title)
+      expect(response.body).not_to match(offer.title)
+      get contributions_url, params: {ContributionType: {'Offer' => 1}}
+      expect(response.body).not_to match(ask.title)
+      expect(response.body).to match(offer.title)
+      get contributions_url, params: {ContributionType: {'Ask' => 1, 'Offer' => 1}}
+      expect(response.body).to match(ask.title)
+      expect(response.body).to match(offer.title)
+    end
+
+    it 'parses requests for a filtered list' do
+      categories = [
+        create(:category, id: 50, name: Faker::Lorem.word),
+        create(:category, id: 70, name: Faker::Lorem.word)
+      ]
+      both_tags_listing = create(:listing, tag_list: categories.map(&:name))
+      expected_area = both_tags_listing.service_area
+      expected_area.name = Faker::Address.community
+      expected_area.save!
+      one_tag_listing = create(:listing, service_area: expected_area, tag_list: categories.sample.name)
+      both_tags_wrong_area_listing = create(:listing, tag_list: categories.map(&:name))
+      no_tags_correct_area_listing = create(:listing, service_area: expected_area)
+
+      # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
+      get contributions_url, params: { 'Category[50]': 1, 'Category[70]': 1, "ServiceArea[#{expected_area.id}]": 1 }, headers: {'HTTP_ACCEPT' => 'application/json'}
+
+      expect(response.body).to match(/#{expected_area.name.to_json}/)
+
+      response_ids = JSON.parse(response.body).map { |hash| hash['id']}
+      expect(response_ids).to include(both_tags_listing.id)
+      expect(response_ids).to include(one_tag_listing.id)
+      expect(response_ids).not_to include(both_tags_wrong_area_listing.id)
+      expect(response_ids).not_to include(no_tags_correct_area_listing.id)
+    end
+  end
 end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -2,179 +2,179 @@ require 'rails_helper'
 
 RSpec.describe "/listings", type: :request do
   # TODO - get these working again once ListingsController#index -> ContributionsController#index
-  # let(:valid_attributes) {{
-  #   location_attributes: {zip: "12345"},
-  #   tag_list: ["", "cash"],
-  #   # name: Faker::Name.name,
-  #   # email: Faker::Internet.email,
-  #   # phone: Faker::PhoneNumber.phone_number
-  # }}
-  #
-  # let(:invalid_attributes) {{
-  #   location_attributes: {zip: "12e45"},
-  # }}
-  #
-  # before { sign_in create(:user) }
-  #
-  # describe "GET /index" do
-  #   it "renders a successful response" do
-  #     create(:listing)
-  #     get listings_url
-  #     expect(response).to be_successful
-  #   end
-  #
-  #   it 'allows asking for a specific subtype of listing' do
-  #     ask = create(:ask, title: 'this is the ask title')
-  #     offer = create(:offer, title: 'this is the offer title')
-  #     get listings_url, params: {ContributionType: {'Ask' => 1}}
-  #     expect(response.body).to match(ask.title)
-  #     expect(response.body).not_to match(offer.title)
-  #     get listings_url, params: {ContributionType: {'Offer' => 1}}
-  #     expect(response.body).not_to match(ask.title)
-  #     expect(response.body).to match(offer.title)
-  #     get listings_url, params: {ContributionType: {'Ask' => 1, 'Offer' => 1}}
-  #     expect(response.body).to match(ask.title)
-  #     expect(response.body).to match(offer.title)
-  #   end
-  #
-  #   it 'parses requests for a filtered list' do
-  #     categories = [
-  #       create(:category, id: 50, name: Faker::Lorem.word),
-  #       create(:category, id: 70, name: Faker::Lorem.word)
-  #     ]
-  #     both_tags_listing = create(:listing, tag_list: categories.map(&:name))
-  #     expected_area = both_tags_listing.service_area
-  #     expected_area.name = Faker::Address.community
-  #     expected_area.save!
-  #     one_tag_listing = create(:listing, service_area: expected_area, tag_list: categories.sample.name)
-  #     both_tags_wrong_area_listing = create(:listing, tag_list: categories.map(&:name))
-  #     no_tags_correct_area_listing = create(:listing, service_area: expected_area)
-  #
-  #     # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
-  #     get listings_url, params: { 'Category[50]': 1, 'Category[70]': 1, "ServiceArea[#{expected_area.id}]": 1 }, headers: {'HTTP_ACCEPT' => 'application/json'}
-  #
-  #     expect(response.body).to match(/#{expected_area.name.to_json}/)
-  #
-  #     response_ids = JSON.parse(response.body).map { |hash| hash['id']}
-  #     expect(response_ids).to include(both_tags_listing.id)
-  #     expect(response_ids).to include(one_tag_listing.id)
-  #     expect(response_ids).not_to include(both_tags_wrong_area_listing.id)
-  #     expect(response_ids).not_to include(no_tags_correct_area_listing.id)
-  #   end
-  # end
-  #
-  # describe "GET /show" do
-  #   it "renders a successful response" do
-  #     listing = create(:listing, :with_location)
-  #     get listing_url(listing)
-  #     expect(response).to be_successful
-  #   end
-  #
-  #   it "renders a response for a listing without a location" do
-  #     # pending "TODO: this doesn't work yet"
-  #     listing = create(:listing)
-  #     get listing_url(listing)
-  #     expect(response).to be_successful
-  #   end
-  # end
-  #
-  # describe "GET /new" do
-  #   before { get new_listing_url }
-  #
-  #   it "renders a successful response" do
-  #     expect(response).to be_successful
-  #   end
-  #
-  #   it "includes fields for nested models" do
-  #     skip # TODO - fixme
-  #     expect(response.body).to include "listing_location_attributes_street"
-  #   end
-  # end
-  #
-  # describe "GET /edit" do
-  #   it "render a successful response" do
-  #     listing = create(:listing)
-  #     get edit_listing_url(listing)
-  #     expect(response).to be_successful
-  #   end
-  # end
-  #
-  # describe "POST /create" do
-  #   context "with valid parameters" do
-  #     it "creates a new Listing and Location" do
-  #       pending "relationship between contribution form and addresses is tbd"
-  #       expect {
-  #         post listings_url, params: { listing: valid_attributes }
-  #       }.to  change(Listing, :count).by(1)
-  #        .and change(Location, :count).by(1)
-  #     end
-  #
-  #     it "redirects to the created listing" do
-  #       pending "relationship between contribution form and addresses is tbd"
-  #       post listings_url, params: { listing: valid_attributes }
-  #       expect(response).to redirect_to(listing_url(Listing.last))
-  #     end
-  #   end
-  #
-  #   context "with invalid parameters" do
-  #     it "does not create a new Listing" do
-  #       expect {
-  #         post listings_url, params: { listing: invalid_attributes }
-  #       }.to change(Listing, :count).by(0)
-  #     end
-  #
-  #     it "renders a successful response (i.e. to display the 'new' template)" do
-  #       post listings_url, params: { listing: invalid_attributes }
-  #       expect(response).to be_successful
-  #     end
-  #   end
-  # end
-  #
-  # describe "PATCH /update" do
-  #   let(:listing) { create(:listing) }
-  #
-  #   context "with valid parameters" do
-  #     let(:new_street_address) { Faker::Address.street_address }
-  #     let(:new_attributes) {{
-  #       location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
-  #     }}
-  #
-  #     before do
-  #       #patch listing_url(listing), params: { listing: new_attributes }
-  #     end
-  #
-  #     it "updates the requested listing" do
-  #       pending "relationship between contribution form and addresses is tbd"
-  #       expect(listing.reload.location.street_address).to eq(new_street_address)
-  #     end
-  #
-  #     it "redirects to the listing" do
-  #       pending "relationship between contribution form and addresses is tbd"
-  #       expect(response).to redirect_to(listing_url(listing))
-  #     end
-  #   end
-  #
-  #   context "with invalid parameters" do
-  #     it "renders a successful response (i.e. to display the 'edit' template)" do
-  #       pending "relationship between contribution form and addresses is tbd"
-  #       patch listing_url(listing), params: { listing: invalid_attributes }
-  #       expect(response).to be_successful
-  #     end
-  #   end
-  # end
-  #
-  # pending "DELETE /destroy" do
-  #   it "destroys the requested listing" do
-  #     listing = Listing.create! valid_attributes
-  #     expect {
-  #       delete listing_url(listing)
-  #     }.to change(Listing, :count).by(-1)
-  #   end
-  #
-  #   it "redirects to the listings list" do
-  #     listing = Listing.create! valid_attributes
-  #     delete listing_url(listing)
-  #     expect(response).to redirect_to(listings_url)
-  #   end
-  # end
+  let(:valid_attributes) {{
+    location_attributes: {zip: "12345"},
+    tag_list: ["", "cash"],
+    # name: Faker::Name.name,
+    # email: Faker::Internet.email,
+    # phone: Faker::PhoneNumber.phone_number
+  }}
+
+  let(:invalid_attributes) {{
+    location_attributes: {zip: "12e45"},
+  }}
+
+  before { sign_in create(:user) }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      create(:listing)
+      get listings_url
+      expect(response).to be_successful
+    end
+
+    it 'allows asking for a specific subtype of listing' do
+      ask = create(:ask, title: 'this is the ask title')
+      offer = create(:offer, title: 'this is the offer title')
+      get listings_url, params: {ContributionType: {'Ask' => 1}}
+      expect(response.body).to match(ask.title)
+      expect(response.body).not_to match(offer.title)
+      get listings_url, params: {ContributionType: {'Offer' => 1}}
+      expect(response.body).not_to match(ask.title)
+      expect(response.body).to match(offer.title)
+      get listings_url, params: {ContributionType: {'Ask' => 1, 'Offer' => 1}}
+      expect(response.body).to match(ask.title)
+      expect(response.body).to match(offer.title)
+    end
+
+    it 'parses requests for a filtered list' do
+      categories = [
+        create(:category, id: 50, name: Faker::Lorem.word),
+        create(:category, id: 70, name: Faker::Lorem.word)
+      ]
+      both_tags_listing = create(:listing, tag_list: categories.map(&:name))
+      expected_area = both_tags_listing.service_area
+      expected_area.name = Faker::Address.community
+      expected_area.save!
+      one_tag_listing = create(:listing, service_area: expected_area, tag_list: categories.sample.name)
+      both_tags_wrong_area_listing = create(:listing, tag_list: categories.map(&:name))
+      no_tags_correct_area_listing = create(:listing, service_area: expected_area)
+
+      # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
+      get listings_url, params: { 'Category[50]': 1, 'Category[70]': 1, "ServiceArea[#{expected_area.id}]": 1 }, headers: {'HTTP_ACCEPT' => 'application/json'}
+
+      expect(response.body).to match(/#{expected_area.name.to_json}/)
+
+      response_ids = JSON.parse(response.body).map { |hash| hash['id']}
+      expect(response_ids).to include(both_tags_listing.id)
+      expect(response_ids).to include(one_tag_listing.id)
+      expect(response_ids).not_to include(both_tags_wrong_area_listing.id)
+      expect(response_ids).not_to include(no_tags_correct_area_listing.id)
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      listing = create(:listing, :with_location)
+      get listing_url(listing)
+      expect(response).to be_successful
+    end
+
+    it "renders a response for a listing without a location" do
+      # pending "TODO: this doesn't work yet"
+      listing = create(:listing)
+      get listing_url(listing)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /new" do
+    before { get new_listing_url }
+
+    it "renders a successful response" do
+      expect(response).to be_successful
+    end
+
+    it "includes fields for nested models" do
+      skip # TODO - fixme
+      expect(response.body).to include "listing_location_attributes_street"
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      listing = create(:listing)
+      get edit_listing_url(listing)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new Listing and Location" do
+        pending "relationship between contribution form and addresses is tbd"
+        expect {
+          post listings_url, params: { listing: valid_attributes }
+        }.to  change(Listing, :count).by(1)
+         .and change(Location, :count).by(1)
+      end
+
+      it "redirects to the created listing" do
+        pending "relationship between contribution form and addresses is tbd"
+        post listings_url, params: { listing: valid_attributes }
+        expect(response).to redirect_to(listing_url(Listing.last))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new Listing" do
+        expect {
+          post listings_url, params: { listing: invalid_attributes }
+        }.to change(Listing, :count).by(0)
+      end
+
+      it "renders a successful response (i.e. to display the 'new' template)" do
+        post listings_url, params: { listing: invalid_attributes }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    let(:listing) { create(:listing) }
+
+    context "with valid parameters" do
+      let(:new_street_address) { Faker::Address.street_address }
+      let(:new_attributes) {{
+        location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
+      }}
+
+      before do
+        #patch listing_url(listing), params: { listing: new_attributes }
+      end
+
+      it "updates the requested listing" do
+        pending "relationship between contribution form and addresses is tbd"
+        expect(listing.reload.location.street_address).to eq(new_street_address)
+      end
+
+      it "redirects to the listing" do
+        pending "relationship between contribution form and addresses is tbd"
+        expect(response).to redirect_to(listing_url(listing))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders a successful response (i.e. to display the 'edit' template)" do
+        pending "relationship between contribution form and addresses is tbd"
+        patch listing_url(listing), params: { listing: invalid_attributes }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  pending "DELETE /destroy" do
+    it "destroys the requested listing" do
+      listing = Listing.create! valid_attributes
+      expect {
+        delete listing_url(listing)
+      }.to change(Listing, :count).by(-1)
+    end
+
+    it "redirects to the listings list" do
+      listing = Listing.create! valid_attributes
+      delete listing_url(listing)
+      expect(response).to redirect_to(listings_url)
+    end
+  end
 end


### PR DESCRIPTION
### Changes
- simplify how the browse filter parser is called from the controller
- duplicate the code from the listings controller into the contributions controller
- comment out the public_contributions route as it was masking a path mentioned later in the routes file
- get all the tests to pass

### Notes
I wasn't happy with this code when I wrote it — it's too complicated for me to follow and remember what I did, and I knew that when I finished writing it. I'm glad there's a reason now for me to have a go at cleaning it up, if only partially.