### PR TITLE
Update rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,15 @@ within it. This allows for any unexpected state data of the user from hanging ar
 ## Data
 * Running `db:seed` will create basic types, etc, for test and production environments.
 * We also added some fake data seed files for you to use that are callable via rake tasks (these are in `lib/tasks/db.rake`) 
-  - If you want to start fresh: `rake db:reset_seeded` (drop, create, migrate, seed, stats_check)
-  - If you want to add some seeds: `rake db:import_all_seeds` (import_dev_seeds, import_submission_response_seeds, import_user_seeds, import_custom_form_question_seeds, stats_check)
-  - Other options: 
-    - `rake db:reset_seed_data` (delete_all_data, seed, import_all_seeds, stats_check)
-    - `rake db:setup_seeds` (setup, import_all_seeds, stats_check)
+  - To start fresh with prod seeds only: `rake db:rebuild_and_seed`
+  - To add some dev seeds: `rake db:import_all_seeds` 
+  - All options: 
+    - `rake db:rebuild_and_seed` (drop, create, migrate, seed, stats_check)
+    - `rake db:rebuild_and_seed_dev` (drop, create, migrate, seed, import_all_seeds, stats_check)
     - `rake db:stats_check` (outputs record totals)
-    - `rake db:delete_all_data` (runs truncate on all tables)
+    - `rake db:truncate_tables` (runs truncate on all tables)
+    - `rake db:recreate_all_seeds` (delete_all_data, seed, import_all_seeds, stats_check)   
+    - `rake db:import_all_seeds` (import_dev_seeds, import_submission_response_seeds, import_user_seeds, import_custom_form_question_seeds, stats_check)
     - `rake db:import_dev_seeds` (runs the db/seeds/dev_seeds.rb file)
     - `rake db:import_submission_response_seeds` (runs the db/scripts/submission_response_seeds.rb file -- you could edit this to pull from the db/seeds/gitignored_csvs path if you have a file you want to import)
     - `rake db:import_user_seeds` (runs the db/scripts/user_seeds.rb file)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,20 +4,23 @@ desc "Extra db functions: stats_check, reset db with seeds, import csv and seed 
 
 namespace :db do
 
-  task :reset_seeded => ['db:drop',
-                         'db:create',
-                         'db:migrate',
-                         'db:seed',
-                         'db:stats_check']
+  task :rebuild_and_seed_dev => ['db:drop',
+                                 'db:create',
+                                 'db:migrate',
+                                 'db:seed',
+                                 'db:import_all_seeds',
+                                 'db:stats_check']
 
-  task :reset_seed_data => ['db:delete_all_data',
-                            'db:seed',
-                            'db:import_all_seeds',
-                            'db:stats_check']
+  task :rebuild_and_seed => ['db:drop',
+                             'db:create',
+                             'db:migrate',
+                             'db:seed',
+                             'db:stats_check']
 
-  task :setup_seeds => ['db:setup',
-                        'db:import_all_seeds',
-                        'db:stats_check']
+  task :recreate_all_seeds => ['db:truncate_tables',
+                               'db:seed',
+                               'db:import_all_seeds',
+                               'db:stats_check']
 
   task :import_all_seeds => ['db:import_dev_seeds',
                              'db:import_submission_response_seeds',
@@ -29,7 +32,7 @@ namespace :db do
     require "#{Rails.root}/db/scripts/tuple_counts.rb"
   end
 
-  task :delete_all_data => :environment do
+  task :truncate_tables => :environment do
     require "#{Rails.root}/db/scripts/truncate_tables.rb"
   end
 


### PR DESCRIPTION
- Update custom db rake task names, and corresponding references in README
 
(I'd found myself forgetting which task was which, so hopefully these make it clearer!)

They could still be improved upon, but here's excerpt from README
```
  - All options: 
    - `rake db:rebuild_and_seed` (drop, create, migrate, seed, stats_check)
    - `rake db:rebuild_and_seed_dev` (drop, create, migrate, seed, import_all_seeds, stats_check)
    - `rake db:stats_check` (outputs record totals)
    - `rake db:delete_all_data` (runs truncate on all tables)
    - `rake db:truncate_tables` (runs truncate on all tables)
    - `rake db:recreate_all_seeds` (delete_all_data, seed, import_all_seeds, stats_check)   
    - `rake db:import_all_seeds` (import_dev_seeds, import_submission_response_seeds, import_user_seeds, import_custom_form_question_seeds, stats_check)
    - `rake db:import_dev_seeds` (runs the db/seeds/dev_seeds.rb file)
    - `rake db:import_submission_response_seeds` (runs the db/scripts/submission_response_seeds.rb file -- you could edit this to pull from the db/seeds/gitignored_csvs path if you have a file you want to import)
    - `rake db:import_user_seeds` (runs the db/scripts/user_seeds.rb file)
```