### PR TITLE
Update seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,6 +72,9 @@ end
   ['Text', 'phone', 'fa fa-comment'],
   ['Email', 'email', 'fa fa-envelope'],
   ['WhatsApp', 'phone', 'fa fa-whatsapp'],
+  # ['Instagram', 'notes', 'fa fa-instagram'], # TODO - enable social media options
+  # ['Facebook', 'notes', 'fa fa-facebook'],
+  # ['Twitter', 'notes', 'fa fa-twitter'],
 ].
   each do |(name, field, icon_class)|
     ContactMethod.find_or_create_by!(name: name, field: field, enabled: true, icon_class: icon_class)

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -13,7 +13,7 @@ location_type = LocationType.all.sample
 5.times do
   # every service_area gets its own location
   location = Location.new(location_type: location_type)
-  ServiceArea.create!(name: Faker::Address.community, location: location, organization: host_organization, service_area_type: ServiceArea::TYPES)
+  ServiceArea.create!(name: Faker::Address.community, location: location, organization: host_organization, service_area_type: ServiceArea::TYPES.sample)
 end
 
 email_contact_method = ContactMethod.field_name('email').first || ContactMethod.create!(name: "Email", field: "email", enabled: true)

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -117,6 +117,7 @@ CommunicationLog.where(
 CommunicationLog.where(
     subject: "we'd like your feedback!",
     body: "how was your experience?",
+    person: person,
     delivery_method: ContactMethod.email,
     delivery_status: "completed",
     auto_generated: true,

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -79,7 +79,7 @@ end
 # matches
 #
 
-match_1 = Match.where(receiver: person, provider: person_2.offers.last).first_or_create!
+match_1 = Match.where(receiver: person.asks.last, provider: person_2.offers.last).first_or_create!
 5.times do
   Match.where(receiver: Ask.all.sample, provider: Offer.all.sample).first_or_create!
 end


### PR DESCRIPTION
- Add TODO/comment re social media ContactMethods. This is a discussion topic -- my vote is to add them.
- Don't make any matches directly on Person (we decided to only match between Listings and CommunityResources
- Add Person param to communication_log seeds
- Change state/status code on listing seeds
- Change ServiceArea type to sample list (instead of using the whole list)