### PR TITLE
Add location type to ask/offer form

### DIFF
--- a/app/blueprints/category_blueprint.rb
+++ b/app/blueprints/category_blueprint.rb
@@ -4,8 +4,8 @@ class CategoryBlueprint < Blueprinter::Base
   field :name
   field :description
 
-  view :normal do
-    # Note we are _not_ propogating the :normal view to children.
+  view :with_subcategories do
+    # Note we are _not_ propogating the :with_subcategories view to children.
     # This is intentional because we don't currently have multiply
     # nested categories so we don't need to dig any deeper.
     association :categories, name: :subcategories, blueprint: CategoryBlueprint

--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -1,0 +1,13 @@
+class ConfigurationBlueprint < Blueprinter::Base
+  association :categories, blueprint: CategoryBlueprint, view: :with_subcategories do
+    Category.visible.roots.includes(:categories)
+  end
+
+  association :contact_methods, blueprint: ContactMethodBlueprint do
+    ContactMethod.enabled
+  end
+
+  association(:service_areas, blueprint: ServiceAreaBlueprint) do
+    ServiceArea.all.eager_load(:string_translations, :text_translations)
+  end
+end

--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -7,6 +7,10 @@ class ConfigurationBlueprint < Blueprinter::Base
     ContactMethod.enabled
   end
 
+  association :location_types, blueprint: LocationTypeBlueprint do
+    LocationType.all  # FIXME: fix seeds so we can change this to `.visible`
+  end
+
   association(:service_areas, blueprint: ServiceAreaBlueprint) do
     ServiceArea.all.eager_load(:string_translations, :text_translations)
   end

--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -12,6 +12,6 @@ class ConfigurationBlueprint < Blueprinter::Base
   end
 
   association(:service_areas, blueprint: ServiceAreaBlueprint) do
-    ServiceArea.all.eager_load(:string_translations, :text_translations)
+    ServiceArea.publicly_visible.eager_load(:string_translations, :text_translations)
   end
 end

--- a/app/blueprints/listing_blueprint.rb
+++ b/app/blueprints/listing_blueprint.rb
@@ -7,7 +7,7 @@ class ListingBlueprint < Blueprinter::Base
     :type
   )
 
-  view :normal do
+  view :with_person do
     association :person, blueprint: PersonBlueprint, view: :normal
   end
 end

--- a/app/blueprints/listing_blueprint.rb
+++ b/app/blueprints/listing_blueprint.rb
@@ -8,6 +8,6 @@ class ListingBlueprint < Blueprinter::Base
   )
 
   view :with_person do
-    association :person, blueprint: PersonBlueprint, view: :normal
+    association :person, blueprint: PersonBlueprint
   end
 end

--- a/app/blueprints/location_blueprint.rb
+++ b/app/blueprints/location_blueprint.rb
@@ -3,7 +3,7 @@ class LocationBlueprint < Blueprinter::Base
 
   fields :street_address, :neighborhood, :city, :state, :zip, :county, :region
 
-  view :normal do
+  view :with_location_type do
     association :location_type, blueprint: LocationTypeBlueprint
   end
 end

--- a/app/blueprints/person_blueprint.rb
+++ b/app/blueprints/person_blueprint.rb
@@ -5,6 +5,6 @@ class PersonBlueprint < Blueprinter::Base
   field  :preferred_contact_method
 
   view :normal do
-    association :location, blueprint: LocationBlueprint
+    association :location, blueprint: LocationBlueprint, view: :with_location_type
   end
 end

--- a/app/blueprints/person_blueprint.rb
+++ b/app/blueprints/person_blueprint.rb
@@ -4,7 +4,7 @@ class PersonBlueprint < Blueprinter::Base
   fields :name, :email, :phone, :skills
   field  :preferred_contact_method
 
-  view :normal do
+  view :with_location do
     association :location, blueprint: LocationBlueprint, view: :with_location_type
   end
 end

--- a/app/blueprints/submission_blueprint.rb
+++ b/app/blueprints/submission_blueprint.rb
@@ -2,7 +2,12 @@ class SubmissionBlueprint < Blueprinter::Base
   identifier :id
 
   association :service_area, blueprint: ServiceAreaBlueprint
-  association :person, blueprint: PersonBlueprint, view: :normal
+
+  association :person, blueprint: PersonBlueprint
+
+  association :location, blueprint: LocationBlueprint, view: :with_location_type do |submission|
+    submission&.person&.location
+  end
 
   association :listing, blueprint: ListingBlueprint do |submission|
     submission.listings.first

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -22,7 +22,6 @@ class AsksController < PublicController
       params[:submission].tap do |p|
         p[:form_name] = 'Ask_form'
         p[:listing_attributes][:type] = 'Ask'
-        p[:location_attributes][:location_type] = LocationType.first  # FIXME: add field on form instead
       end
     end
 

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -29,9 +29,7 @@ class AsksController < PublicController
     def serialize(submission)
       @json = {
         submission: SubmissionBlueprint.render_as_hash(submission),
-        categories: CategoryBlueprint.render_as_hash(Category.visible.roots, view: :normal),
-        contact_methods: ContactMethodBlueprint.render_as_hash(ContactMethod.enabled),
-        service_areas: ServiceAreaBlueprint.render_as_hash(ServiceArea.all),
+        configuration: ConfigurationBlueprint.render_as_hash(nil),
       }.to_json
     end
 end

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -17,16 +17,6 @@ class AsksController < PublicController
     end
   end
 
-  def update # for rails-side edits
-    @listing = Listing.find(params[:id])
-    if @listing.save
-      redirect_to listings_path, notice: 'Listing was successfully updated.'
-    else
-      set_form_dropdowns
-      render :edit
-    end
-  end
-
   private
     def submission_params
       params[:submission].tap do |p|

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -24,7 +24,6 @@ class OffersController < PublicController
       params[:submission].tap do |p|
         p[:form_name] = 'Offer_form'
         p[:listing_attributes][:type] = 'Offer'
-        p[:location_attributes][:location_type] = LocationType.first  # FIXME: add field on form instead
       end
     end
 

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -31,9 +31,7 @@ class OffersController < PublicController
     def serialize(submission)
       @json = {
         submission: SubmissionBlueprint.render_as_hash(submission),
-        categories: CategoryBlueprint.render_as_hash(Category.visible.roots, view: :normal),
-        contact_methods: ContactMethodBlueprint.render_as_hash(ContactMethod.enabled),
-        service_areas: ServiceAreaBlueprint.render_as_hash(ServiceArea.all),
+        configuration: ConfigurationBlueprint.render_as_hash(nil),
       }.to_json
     end
 end

--- a/app/forms/listing_form.rb
+++ b/app/forms/listing_form.rb
@@ -11,7 +11,7 @@ class ListingForm < BaseForm
   end
 
   def execute
-    (id? ? Listing.find(id) : Listing.new).tap do |listing|
+    Listing.find_or_new(id).tap do |listing|
       listing.attributes = given_inputs
     end
   end

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -14,7 +14,7 @@ class LocationForm < BaseForm
   def execute
     return nil if inputs.values.all?(&:blank?)
 
-    (id? ? Location.find(id) : Location.new).tap do |location|
+    Location.find_or_new(id).tap do |location|
       location.attributes = given_inputs
     end
   end

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -12,6 +12,8 @@ class LocationForm < BaseForm
   end
 
   def execute
+    return nil if inputs.values.all?(&:blank?)
+
     (id? ? Location.find(id) : Location.new).tap do |location|
       location.attributes = given_inputs
     end

--- a/app/forms/person_form.rb
+++ b/app/forms/person_form.rb
@@ -10,7 +10,7 @@ class PersonForm < BaseForm
   end
 
   def execute
-    (id? ? Person.find(id) : Person.new).tap do |person|
+    Person.find_or_new(id).tap do |person|
       person.attributes = given_inputs
     end
   end

--- a/app/forms/submission_form.rb
+++ b/app/forms/submission_form.rb
@@ -10,23 +10,26 @@ class SubmissionForm < BaseForm
   end
 
   def execute
+    build_location
+    build_person
+    build_listing
     build_submission
   end
 
   private
 
-    def location
+    def build_location
       @location ||= LocationForm.build location_attributes
     end
 
-    def person
-      @person ||= PersonForm.build person_attributes.merge location: location
+    def build_person
+      @person ||= PersonForm.build person_attributes.merge location: @location
     end
 
-    def listing
+    def build_listing
       @listing ||= ListingForm.build listing_attributes.merge(
-        person: person,
-        location: location,
+        person: @person,
+        location: @location,
         service_area: service_area
       )
     end
@@ -46,8 +49,8 @@ class SubmissionForm < BaseForm
         )
         .merge(
           body: body_json,
-          person: person,
-          listings: [listing],
+          person: @person,
+          listings: [@listing],
         )
     end
 

--- a/app/javascript/components/forms/LocationFields.vue
+++ b/app/javascript/components/forms/LocationFields.vue
@@ -5,26 +5,53 @@
       label="Street address"
       custom-class="is-medium"
     >
-      <b-input :name="withPrefix('street_address')" :value="street_address" />
+      <b-input :name="withPrefix('street_address')" v-model="streetAddress" />
     </b-field>
 
-    <!-- TODO: replace this with a dropdown -->
-    <b-input :name="withPrefix('location_type')" type="hidden" value="1" />
+    <b-field
+      v-if="streetAddress.length"
+      :label-for="withPrefix('location_type')"
+      label="Address type"
+      custom-class="required-field is-medium"
+    >
+      <b-select
+        :name="withPrefix('location_type')"
+        :value="location_type.id"
+        placeholder="Type"
+        required
+      >
+        <option v-for="{id, name} in location_types" :key="id" :value="id" >
+          {{ name | replace('_', ' ') | capitalize }}
+        </option>
+      </b-select>
+    </b-field>
   </div>
 </template>
 
 <script>
 import {partial} from 'utils/function'
+import {capitalize, replace} from 'utils/string'
 import {fieldNameWithPrefix} from 'utils/form'
 
 export default {
   props: {
     fieldNamePrefix: String,
-    street_address: String,
+    location_types:  Array,
+    location_type:   {type: Object, default: () => { return {} }},
+    street_address:  {type: String, default: ''},
+  },
+  data() {
+    return {
+      streetAddress: this.street_address,
+    }
   },
   created: function() {
     // TODO: tiny bit of duplication with partial+fieldNameWithPrefix
     this.withPrefix = partial(fieldNameWithPrefix, this.fieldNamePrefix)
+  },
+  filters: {
+    capitalize,
+    replace
   },
 }
 </script>

--- a/app/javascript/components/forms/ServiceAreaField.vue
+++ b/app/javascript/components/forms/ServiceAreaField.vue
@@ -3,7 +3,7 @@
     v-if="options.length > 1"
     :label-for="name"
     label="Service area"
-    custom-class="required-field"
+    custom-class="required-field is-medium"
   >
     <b-select
       :name="name"

--- a/app/javascript/pages/Ask.vue
+++ b/app/javascript/pages/Ask.vue
@@ -7,7 +7,7 @@
 
     <ServiceAreaField
       :service_area="submission.service_area"
-      :options="service_areas"
+      :options="configuration.service_areas"
       name="submission[service_area]"
     />
 
@@ -23,13 +23,13 @@
 
     <ContactFields
       fieldNamePrefix="submission[person_attributes]"
-      :contactMethods="contact_methods"
+      :contactMethods="configuration.contact_methods"
       :person="person"
     /><SpacerField />
 
     <CategoryFields
       :fieldNamePrefix="withListingPrefix('tag_list[]')"
-      :categories="categories"
+      :categories="configuration.categories"
       :tags="listing.tag_list"
     >
       <p class="title is-4">
@@ -79,9 +79,7 @@ export default {
   },
   props: {
     submission: Object,
-    categories: Array,
-    contact_methods: Array,
-    service_areas: Array,
+    configuration: Object,
   },
   data() {
     return {

--- a/app/javascript/pages/Ask.vue
+++ b/app/javascript/pages/Ask.vue
@@ -18,7 +18,8 @@
 
     <LocationFields
       fieldNamePrefix="submission[location_attributes]"
-      v-bind="person.location"
+      :location_types="configuration.location_types"
+      v-bind="location"
     /><SpacerField />
 
     <ContactFields
@@ -83,6 +84,7 @@ export default {
   },
   data() {
     return {
+      location: this.submission.location || {},
       listing: this.submission.listing || {},
       person: this.submission.person || {},
     }

--- a/app/javascript/pages/Offer.vue
+++ b/app/javascript/pages/Offer.vue
@@ -7,7 +7,7 @@
 
     <ServiceAreaField
       :service_area="submission.service_area"
-      :options="service_areas"
+      :options="configuration.service_areas"
       name="submission[service_area]"
     />
 
@@ -18,7 +18,7 @@
 
     <ContactFields
       fieldNamePrefix="submission[person_attributes]"
-      :contactMethods="contact_methods"
+      :contactMethods="configuration.contact_methods"
       :person="person"
     /><SpacerField />
 
@@ -29,7 +29,7 @@
 
     <CategoryFields
       :fieldNamePrefix="withListingPrefix('tag_list[]')"
-      :categories="categories"
+      :categories="configuration.categories"
       :tags="listing.tag_list"
     >
       <p class="title is-4">
@@ -107,9 +107,7 @@ export default {
   },
   props: {
     submission: Object,
-    categories: Array,
-    contact_methods: Array,
-    service_areas: Array,
+    configuration: Object,
   },
   data() {
     return {

--- a/app/javascript/pages/Offer.vue
+++ b/app/javascript/pages/Offer.vue
@@ -24,7 +24,8 @@
 
     <LocationFields
       fieldNamePrefix="submission[location_attributes]"
-      v-bind="person.location"
+      :location_types="configuration.location_types"
+      v-bind="location"
     /><SpacerField />
 
     <CategoryFields
@@ -111,6 +112,7 @@ export default {
   },
   data() {
     return {
+      location: this.submission.location || {},
       listing: this.submission.listing || {},
       person: this.submission.person || {},
     }

--- a/app/javascript/utils/string.js
+++ b/app/javascript/utils/string.js
@@ -2,3 +2,8 @@ export function capitalize(string) {
   if (!string) return ''
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
+
+export function replace(string, target, replacement) {
+  if (!string) return ''
+  return string.replace(target, replacement)
+}

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.find_or_new id
+    return new if id.nil?
+    find_by(id: id) || new
+  end
 end

--- a/app/models/location_type.rb
+++ b/app/models/location_type.rb
@@ -1,4 +1,6 @@
 class LocationType < ApplicationRecord
   has_many :locations
   SERVICE_AREA_TYPE = "service_area"
+
+  scope :visible, -> { where(display_to_public: true) }
 end

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -30,6 +30,7 @@ class ServiceArea < ApplicationRecord
   }
 
   scope :as_filter_types, -> { i18n.select :id, :name }
+  scope :publicly_visible, -> { where(display_to_public: true) }
 
   def full_name
     "#{ parent.name.upcase + ": " if parent}#{name}#{ " (" + service_area_type + ")" if service_area_type}"

--- a/spec/forms/submission_form_spec.rb
+++ b/spec/forms/submission_form_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe SubmissionForm do
         it 'set the specified location_type' do
           expect(location.location_type).to eq location_type
         end
+
+        context 'which is optional' do
+          before do
+            params[:location_attributes] = {
+              street_address: '',
+            }
+          end
+
+          it 'allows for the rest of submission to be valid' do
+            expect(submission).to be_valid
+            expect(submission.person.location).to be_nil
+          end
+        end
       end
     end
 

--- a/spec/javascript/pages/Offer.spec.js
+++ b/spec/javascript/pages/Offer.spec.js
@@ -7,9 +7,11 @@ describe('Offer', () => {
   def('wrapper', () => mount(Offer, {
     localVue: configure(createLocalVue()),
     propsData: {
-      contact_methods: $contact_methods,
-      service_areas: $service_areas,
       submission: $submission,
+      configuration: {
+        contact_methods: $contact_methods,
+        service_areas: $service_areas,
+      },
     },
   }))
 


### PR DESCRIPTION
Also introduces a `ConfigurationBlueprint` object that consolidates `ServiceArea`, `LocationType`, `ContactMethod` configurations so controllers don't have to know this logic.

Fixes #191 