### PR TITLE
Add fields so confirmation page is configurable

### DIFF
--- a/app/controllers/system_settings_controller.rb
+++ b/app/controllers/system_settings_controller.rb
@@ -52,18 +52,25 @@ class SystemSettingsController < ApplicationController
 
     def system_setting_params
       params.require(:system_setting).permit(
+        :allow_sms,
         :exchange_type,
         :separate_asks_offers,
-        :allow_sms,
-        :community_resources_module,
+
         :announcements_module,
-        :positions_module,
+        :community_resources_module,
         :donations_module,
-        :shared_accounts_module,
         :chat_module,
+        :positions_module,
+        :shared_accounts_module,
+
         :about_us_text,
+        :confirmation_page_text_header,
+        :confirmation_page_text_body,
+        :confirmation_page_text_link_header,
+        :confirmation_page_text_footer,
         :landing_page_text_what,
         :landing_page_text_who,
-        :landing_page_text_how)
+        :landing_page_text_how,
+      )
     end
 end

--- a/app/views/contributions/thank_you.html.erb
+++ b/app/views/contributions/thank_you.html.erb
@@ -2,36 +2,39 @@
   <%= @current_organization&.name %>
 </div>
 
-<div class="subtitle is-3">
-  Thank you for your submission!
-</div>
-
-<div>
-  We've sent you a confirmation email (if you provided an email).
+<div class="header">
+  <%= @system_setting.confirmation_page_text_header.html_safe %>
 </div>
 
 <hr>
 
-<div class="subtitle is-4">
+<div class="body">
   <!-- # TODO extract this text to exchange_type model data -->
   <% if @system_setting.exchange_type == "peer_to_peer" %>
     Check out our <%= link_to "contributions page", contributions_public_path %> to see Asks, Offers, and Community Resources.
   <% elsif @system_setting.exchange_type == "fully_moderated" %>
-    We'll be in touch if we're able to find a match.
+    <%= @system_setting.confirmation_page_text_body.html_safe %><!-- # TODO change system text handling so each exchange_type has text -->
   <% else %>
     We'll assist as best we can!
   <% end %>
   <hr>
 </div>
 
-<div class="links-header">
-  <%= "Check these out:" if @system_setting.community_resources_module? || @system_setting.announcements_module? %>
+<div class="links">
+  <div class="links-header">
+    <%= @system_setting.confirmation_page_text_link_header.html_safe if @system_setting.community_resources_module? || @system_setting.announcements_module? %>
+  </div>
+
+  <div class="community-resources-link">
+    <%= link_to "Community Resources", community_resources_public_path if @system_setting.community_resources_module? %>
+  </div>
+
+  <div class="announcements-link">
+    <%= link_to "Announcements", announcements_public_path if @system_setting.announcements_module? %>
+  </div>
 </div>
 
-<div class="community-resources-link">
-  <%= link_to "Community Resources", community_resources_public_path if @system_setting.community_resources_module? %>
+<div class="footer">
+  <%= @system_setting.confirmation_page_text_footer.html_safe %>
 </div>
 
-<div class="announcements-link">
-  <%= link_to "Announcements", announcements_public_path if @system_setting.announcements_module? %>
-</div>

--- a/app/views/system_settings/_form.html.erb
+++ b/app/views/system_settings/_form.html.erb
@@ -12,10 +12,45 @@
     <%= f.input :shared_accounts_module, as: :radio_buttons %>
     <%= f.input :chat_module, as: :radio_buttons %>
     <%= f.input :about_us_text, label: "About us text (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
-    <div class="field is-grouped">
-      <%= f.input :landing_page_text_who, label: "Landing page text: Who (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
-      <%= f.input :landing_page_text_what, label: "Landing page text: What (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
-      <%= f.input :landing_page_text_how, label: "Landing page text: How (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
+    <div class="is-inline-flex">
+      <%= f.input :landing_page_text_who,
+                  label: "Landing page text: Who (
+                           <a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
+      <%= f.input :landing_page_text_what,
+                  label: "Landing page text: What (
+                           <a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
+      <%= f.input :landing_page_text_how,
+                  label: "Landing page text: How (
+                           <a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe %>
+    </div>
+    <div class="is-inline-flex">
+      <%= f.input :confirmation_page_text_header,
+                  as: :text,
+                  label: "Submission confirmation (thank you) page text: Header
+                  (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe,
+                  input_html: { value: f.object.confirmation_page_text_header ||
+                      "<div class='subtitle is-3'>Thank you for your submission!</div>
+                      <div>We've sent you a confirmation email (if you provided an email).</div>" } %>
+      <%= f.input :confirmation_page_text_body,
+                  as: :text,
+                  label: "Submission confirmation (thank you) page text: Body
+                  (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe,
+                  input_html: { value: f.object.confirmation_page_text_body ||
+                      "<div class='subtitle is-5'>We'll be in touch if we're able to find a match.</div>" }
+      %>
+      <%= f.input :confirmation_page_text_link_header,
+                  as: :text,
+                  label: "Submission confirmation (thank you) page text: Links
+                  (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe,
+                  input_html: { value: f.object.confirmation_page_text_link_header ||
+                      "Check these out:" }
+      %>
+      <%= f.input :confirmation_page_text_footer,
+                  as: :text,
+                  label: "Submission confirmation (thank you)  page text: Footer
+                  (<a href='https://htmleditor.io/'>HTML-enabled</a>)".html_safe,
+                  input_html: { value: f.object.confirmation_page_text_footer }
+      %>
     </div>
   </div>
 

--- a/db/migrate/20200604102243_add_confirmation_page_text_fields_to_system_settings.rb
+++ b/db/migrate/20200604102243_add_confirmation_page_text_fields_to_system_settings.rb
@@ -1,0 +1,8 @@
+class AddConfirmationPageTextFieldsToSystemSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :system_settings, :confirmation_page_text_header, :string
+    add_column :system_settings, :confirmation_page_text_body, :string
+    add_column :system_settings, :confirmation_page_text_link_header, :string
+    add_column :system_settings, :confirmation_page_text_footer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_195031) do
+ActiveRecord::Schema.define(version: 2020_06_04_102243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -417,6 +417,10 @@ ActiveRecord::Schema.define(version: 2020_05_26_195031) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "about_us_text"
+    t.string "confirmation_page_text_header"
+    t.string "confirmation_page_text_body"
+    t.string "confirmation_page_text_link_header"
+    t.string "confirmation_page_text_footer"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Confirmation/thank_you page is the one they get taken to after submitting a Contribution
- (there's some things to think abt here as far as if it should be the same page after submitting a Community Resource, and, if Announcement submission should follow suit as well)

- Added fields so users can update confirmation page text: 
  header, body, link_header ("check these out" links section), and footer

TODO: 
- This maybe needs to have more options to handle text specific to their `exchange_type`
- Def need to make sure this is all translatable w Mobility

