### PR TITLE
[239] | Fix sign-out so it 

### DIFF
--- a/app/javascript/components/NavBar.vue
+++ b/app/javascript/components/NavBar.vue
@@ -21,7 +21,7 @@
       <b-navbar-item href="/matches">Matches</b-navbar-item>
       <b-navbar-item href="/admin">Admin</b-navbar-item>
       <b-navbar-item tag="div">
-        <DeleteButton action="users/sign_out">Logout</DeleteButton>
+        <DeleteButton action="/users/sign_out">Logout</DeleteButton>
       </b-navbar-item>
     </template>
     <template slot="end" v-else>


### PR DESCRIPTION
Fixes #239 

This was a small fix. The reason for the behavior was the path was originally a relative path (so it works on the `root_path` but not elsewhere) and it needed to be an absolute path. I added the slash prefix, which does that. 

Tested manually. 