### PR TITLE
Hotfix: drop text_translations reference in ConfigurationBlueprint

### DIFF
--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -12,6 +12,6 @@ class ConfigurationBlueprint < Blueprinter::Base
   end
 
   association(:service_areas, blueprint: ServiceAreaBlueprint) do
-    ServiceArea.publicly_visible.eager_load(:string_translations, :text_translations)
+    ServiceArea.publicly_visible.eager_load(:string_translations)
   end
 end


### PR DESCRIPTION
The association was dropped from `ServiceArea` as a result of a00e5ce.
Ask and Offer forms are broken w/o this fix.