### PR TITLE
Add logo_url and favicon_url to organization for edit by admins

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -49,7 +49,18 @@ class OrganizationsController < ApplicationController
 
     def organization_params
       params.require(:organization).permit(
-          :name, :description, :display_on_org_chart, :facebook_url, :website_url, :phone, :is_instance_owner,
-          :has_sms_account, :has_hosting_account, :has_mailer_account)
+          :description,
+          :display_on_org_chart,
+          :facebook_url,
+          :favicon_url,
+          :has_hosting_account,
+          :has_mailer_account,
+          :has_sms_account,
+          :is_instance_owner,
+          :logo_url,
+          :name,
+          :phone,
+          :website_url,
+          )
     end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <div class="columns text-center login-screen" style="vertical-align:middle;">
   <div class="column is-half logo-image text-center">
-    <%= image_tag 'logo.png', width: 300, alt: 'mutual-aid-app logo'%>
+    <%= image_tag @current_organization.logo_url.present? ? @current_organization.logo_url : "logo.png",
+                  width: 300, alt: 'mutual-aid-app logo'%>
   </div>
   <div class="column is-half text-center">
     <div class="section">

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -6,6 +6,8 @@
     <%= f.input :description, as: :text, input_html: { rows: 2 } %>
     <%= f.input :facebook_url, hint: "(e.g. https://www.google.com)" %>
     <%= f.input :website_url, hint: "(e.g. https://www.google.com)" %>
+    <%= f.input :logo_url, hint: "(e.g. https://www.google.com)" %>
+    <%= f.input :favicon_url, hint: "(e.g. https://www.google.com)" %>
     <%= f.input :phone %>
     <%= f.input :is_instance_owner, as: :radio_buttons %>
     <%= f.input :has_sms_account, as: :radio_buttons %>

--- a/db/migrate/20200604210255_add_logo_url_to_organization.rb
+++ b/db/migrate/20200604210255_add_logo_url_to_organization.rb
@@ -1,0 +1,6 @@
+class AddLogoUrlToOrganization < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :logo_url, :string
+    add_column :organizations, :favicon_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_102243) do
+ActiveRecord::Schema.define(version: 2020_06_04_210255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -244,6 +244,8 @@ ActiveRecord::Schema.define(version: 2020_06_04_102243) do
     t.bigint "location_id"
     t.bigint "service_area_id"
     t.boolean "display_on_org_chart", default: true, null: false
+    t.string "logo_url"
+    t.string "favicon_url"
     t.index ["location_id"], name: "index_organizations_on_location_id"
     t.index ["service_area_id"], name: "index_organizations_on_service_area_id"
   end


### PR DESCRIPTION
- Add logo_url and favicon_url fields to Organization
- On login page, if the @current_organization.logo_url exists, display it instead of default system logo

TODO:
- Make favicon editable as well
- Make @current_organization available on vue side so navbar icon can be adjustable as well
