### PR TITLE
Add unmatched scope to Ask/Offer before pushing to Contributions page

### DIFF
--- a/app/models/ask.rb
+++ b/app/models/ask.rb
@@ -1,6 +1,6 @@
 class Ask < Listing
   belongs_to :service_area, inverse_of: :asks
 
-  scope :unmatched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where("matches.provider_id IS NULL") }
-  scope :matched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where("matches.provider_id IS NOT NULL") }
+  scope :matched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where.not(matches: {provider_id: nil}) }
+  scope :unmatched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where(matches: {provider_id: nil}) }
 end

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -49,7 +49,7 @@ class BrowseFilter
   private
 
   def filter(model)
-    parameters.keys.reduce(model.all) do |scope, key|
+    parameters.keys.reduce(model.unmatched) do |scope, key|
       filter = FILTERS.fetch(key, ->(_condition, s) {s})
       filter.call(parameters[key], scope)
     end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,6 @@
 class Offer < Listing
   belongs_to :service_area, inverse_of: :offers
 
-  scope :matched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where("matches.receiver_id IS NOT NULL") }
-  scope :unmatched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where("matches.receiver_id IS NULL") }
+  scope :matched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where.not(matches: {receiver_id: nil}) }
+  scope :unmatched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where(matches: {receiver_id: nil}) }
 end

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :match do
+
+    association :provider
+    association :receiver
+
+    trait :with_ask_and_offer do
+      association :provider, factory: :offer
+      association :receiver, factory: :ask
+    end
+
+  end
+end

--- a/spec/models/ask_spec.rb
+++ b/spec/models/ask_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Ask do
+  describe 'matched' do
+    it 'returns matched asks' do
+      unmatched_ask = create(:ask)
+      match = create(:match, :with_ask_and_offer)
+      matched_ask = match.receiver
+
+      expect(Ask.matched).to eq([matched_ask])
+    end
+  end
+
+  describe 'unmatched' do
+    it 'returns unmatched asks' do
+      unmatched_ask = create(:ask)
+      match = create(:match, :with_ask_and_offer)
+      matched_ask = match.receiver
+
+      expect(Ask.unmatched).to eq([unmatched_ask])
+    end
+  end
+end

--- a/spec/models/browse_filter_spec.rb
+++ b/spec/models/browse_filter_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe BrowseFilter do
   let(:all_models) { ContributionType::TYPES.map(&:model)}
   it 'ignores urgency levels if all urgency levels are checked because urgency levels are not fully implemented' do
     unmodified_scope = double
-    all_models.each do |model_double|
-      expect(model_double).to receive(:all).and_return(unmodified_scope)
+    all_models.each do |model_class|
+      expect(model_class).to receive(:unmatched).and_return(unmodified_scope)
     end
     expect(unmodified_scope).not_to receive(:where)
     all_urgency_level_ids = UrgencyLevel::TYPES.map(&:id)
     BrowseFilter.new('UrgencyLevel' => all_urgency_level_ids).contributions
   end
 
-  it 'will query for urgnecy levels if only one urgency level is checked' do
+  it 'will query for urgency levels if only one urgency level is checked' do
     used_scope = double
-    all_models.each do |model_double|
-      expect(model_double).to receive(:all).and_return(used_scope)
+    all_models.each do |model_class|
+      expect(model_class).to receive(:unmatched).and_return(used_scope)
     end
     one_urgency_level_id = [UrgencyLevel::TYPES.sample.id]
     expect(used_scope).to receive(:where).with(urgency_level_id: one_urgency_level_id).exactly(ContributionType::TYPES.length).times

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Offer do
+  describe 'matched' do
+    it 'returns matched offers' do
+      unmatched_offer = create(:offer)
+      match = create(:match, :with_ask_and_offer)
+      matched_offer = match.provider
+
+      expect(Offer.matched).to eq([matched_offer])
+    end
+  end
+
+  describe 'unmatched' do
+    it 'returns unmatched offers' do
+      unmatched_offer = create(:offer)
+      match = create(:match, :with_ask_and_offer)
+      matched_offer = match.provider
+
+      expect(Offer.unmatched).to eq([unmatched_offer])
+    end
+  end
+end


### PR DESCRIPTION
Completes #466 

Contributions page should only display `unmatched` contributions. Applying this child-model-level scope properly filters the list.

Idk how/where to write a test for this. Would love help! Ok to merge in the meantime so users are able to see only the "to do" list on Contributions page?