### PR TITLE
Add visible scope to LocationType for display on Forms

### DIFF
--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -8,7 +8,7 @@ class ConfigurationBlueprint < Blueprinter::Base
   end
 
   association :location_types, blueprint: LocationTypeBlueprint do
-    LocationType.all  # FIXME: fix seeds so we can change this to `.visible`
+    LocationType.visible
   end
 
   association(:service_areas, blueprint: ServiceAreaBlueprint) do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,7 +41,10 @@ default_tags.each do |tag_name_parent, subtag_name|
 end
 
 %w[business home cross_street service_area park].each do |location_type_name|
-  LocationType.where(name: location_type_name).first_or_create!
+  location_type = LocationType.where(name: location_type_name).first_or_create!
+  unless location_type_name == "service_area"
+    location_type.update_attributes(display_to_public: true)
+  end
 end
 
 # host org and set system defaults


### PR DESCRIPTION
Only LocationType.visible should display on Forms

- add visible scope to LocationType
- change LocationType seeds so all except 'service_area' are set to `display_to_public: true`