### PR TITLE
Turn parent categories into accordions on Ask/Offer forms

### DIFF
--- a/app/javascript/components/forms/CategoryFields.vue
+++ b/app/javascript/components/forms/CategoryFields.vue
@@ -2,28 +2,47 @@
   <div>
     <slot />
 
-    <div v-for="{id, name, description, subcategories} in categories" :key="id">
-      <b-checkbox
-        v-model="selectedTags"
-        :name="fieldNamePrefix"
-        :native-value="name"
-        size="is-medium"
+    <div v-for="{id, name, description, subcategories} in normalizedCategories" :key="id">
+      <b-collapse
+        :id="`collapse-${id}`"
+        :aria-id="`collapse-content-${id}`"
+        :open="isSelected(name)"
+        class="card"
+        animation="slide"
       >
-        {{ name | capitalize }}
-      </b-checkbox>
+        <div
+          :aria-controls="`collapse-content-${id}`"
+          slot="trigger"
+          slot-scope="collapse"
+          class="card-header"
+          role="button"
+        >
+          <p class="card-header-title has-text-weight-normal is-size-4">
+          {{ name | capitalize }}
+          </p>
+          <a class="card-header-icon">
+            <b-icon :icon="collapse.open ? 'angle-up' : 'angle-down'" />
+          </a>
+        </div>
 
-      <div
-        v-if="isSelected(name)"
-        style="margin-left: 36px"
-      >
-        <p v-if="description" class="help mb-1"> {{ description }} </p>
+        <div class="card-content">
+          <p v-if="description" class="mb-1"> {{ description }} </p>
 
-        <CategoryFields
-          :fieldNamePrefix="fieldNamePrefix"
-          :categories="subcategories"
-          :tags="selectedTags"
-        />
-      </div>
+          <!-- If any subcategories are selected, add parent category to list of tags submitted -->
+          <input v-if="anySelected(subcategories)" :name="fieldNamePrefix" :value="name" type="hidden" />
+
+          <div v-for="{id: subId, name: subName, description: subDescription} in subcategories" :key="subId">
+            <b-checkbox
+              v-model="selectedTags"
+              :name="fieldNamePrefix"
+              :native-value="subName"
+              size="is-medium"
+              >
+              {{ subName | capitalize }}
+            </b-checkbox>
+          </div>
+        </div>
+      </b-collapse>
     </div>
   </div>
 </template>
@@ -40,12 +59,25 @@ export default {
   },
   data() {
     return {
-      selectedTags: this.tags || []
+      selectedTags: this.tags || [],
     }
+  },
+  computed: {
+    normalizedCategories() {
+      this.categories.forEach(({id, name, subcategories}) => {
+        if (!subcategories.length) {
+          subcategories.push({id, name})
+        }
+      })
+      return this.categories
+    },
   },
   methods: {
     isSelected(tag) {
       return this.selectedTags.indexOf(tag) >= 0
+    },
+    anySelected(subcategories) {
+      return subcategories.find(({name}) => this.isSelected(name))
     },
   },
   filters: { capitalize },

--- a/app/javascript/pages/Ask.vue
+++ b/app/javascript/pages/Ask.vue
@@ -33,16 +33,16 @@
       :categories="configuration.categories"
       :tags="listing.tag_list"
     >
-      <p class="title is-4">
+      <p class="label is-medium">
         What are you requesting?
       </p>
     </CategoryFields>
-    <SpacerField />
 
     <!-- TODO: probably needs a different field, not `description` -->
     <CommentsField
       :fieldName="withListingPrefix('description')"
       :value="listing.description"
+      class="mt-2"
     />
 
     <SubmitButton />

--- a/app/javascript/pages/Offer.vue
+++ b/app/javascript/pages/Offer.vue
@@ -33,7 +33,7 @@
       :categories="configuration.categories"
       :tags="listing.tag_list"
     >
-      <p class="title is-4">
+      <p class="label is-medium">
         What are you able to offer?
       </p>
       <p>
@@ -45,13 +45,12 @@
       Your safety is community safety. Do what is best.
       </p>
     </CategoryFields>
-    <SpacerField />
 
     <b-field
       label="Do you have any special skills or particular resources you would like us to be aware of?"
       :label-for="withPersonPrefix('skills')"
       :message="$options.skillsMessage"
-      custom-class="is-medium"
+      custom-class="mt-2 is-medium"
     >
       <b-input :value="person.skills" :name="withPersonPrefix('skills')" type="textarea" rows="2" />
     </b-field>

--- a/spec/javascript/components/forms/CategoryFields.spec.js
+++ b/spec/javascript/components/forms/CategoryFields.spec.js
@@ -18,50 +18,53 @@ describe('CategoryFields', () => {
     }
   })
 
-  function isChecked(value) {
-    return $wrapper.find(`input[value="${value}"]`).element.checked
-  }
-
-  describe('top-level categories', () => {
-    def('categories', () => {
-      return [
-        {name: 'meals',   description: 'on wheels'},
-        {name: 'housing', description: 'is a human right'},
+  def('categories', () => {
+    return [{
+      id: 'meals',   // ids should be integers; using strings to make spec selectors more obvious
+      name: 'meals',
+      description: 'on wheels',
+      subcategories: [
+        {id: 'prepare', name: 'prepare'},
+        {id: 'deliver', name: 'deliver'}
       ]
-    })
-
-    def('tags', () => ['meals'])
-
-    it('renders checkboxes with selected tags checked', () => {
-      assert.isTrue(isChecked('meals'))
-      assert.isFalse(isChecked('housing'))
-    })
-
-    it('shows descriptions for checked categories', () => {
-      assert.include($wrapper.text(), 'on wheels')
-      assert.notInclude($wrapper.text(), 'is a human right')
-    })
+    }, {
+      id: 'housing',
+      name: 'housing',
+      description: 'is a human right',
+      subcategories: [],
+    }]
   })
 
-  describe('with subcategories', () => {
-    def('categories', () => {
-      return [{
-        name: 'meals',
-        subcategories: [
-          {name: 'prepare'},
-          {name: 'deliver'},
-        ],
-      }]
-    })
+  def('tags', () => {
+    return [
+      'meals',
+      'prepare',
+    ]
+  })
 
-    def('tags', () => ['meals', 'prepare'])
+  it('renders accordions for each parent category', () => {
+    assert($wrapper.contains('.collapse#collapse-housing'))
+    assert($wrapper.contains('.collapse#collapse-meals'))
+  })
 
-    it('renders checkboxes for selected subcategories', () => {
-      assert.isTrue(isChecked('meals'))
-      assert.isTrue(isChecked('prepare'))
-      assert.isFalse(isChecked('deliver'))
+  it('opens accordions containing selected subcategories', () => {
+    assert.equal($wrapper.get('#collapse-content-meals').attributes('aria-expanded'), 'true')
+    assert.equal($wrapper.get('#collapse-content-housing').attributes('aria-expanded'), undefined)
+  })
+
+  it('sets a hidden input field for each parent category based on whether any subcategories are selected', () => {
+    assert.isTrue($wrapper.contains('input[type="hidden"][value="meals"]'))
+    assert.isFalse($wrapper.contains('input[type="hidden"][value="housing"]'))
+  })
+
+  it('renders checkboxes for each subcategory, with selected ones checked', () => {
+    assert.isTrue($wrapper.get(`input[value="prepare"]`).element.checked)
+    assert.isFalse($wrapper.get(`input[value="deliver"]`).element.checked)
+  })
+
+  describe('when a parent category has no subcategories', () => {
+    it('renders a checkbox with the same name as the parent', () => {
+      assert($wrapper.contains('input[value="housing"]'))
     })
   })
 })
-
-

--- a/spec/javascript/pages/Offer.spec.js
+++ b/spec/javascript/pages/Offer.spec.js
@@ -9,6 +9,7 @@ describe('Offer', () => {
     propsData: {
       submission: $submission,
       configuration: {
+        categories: [],
         contact_methods: $contact_methods,
         service_areas: $service_areas,
       },


### PR DESCRIPTION
Just a UI change for now, but sets us up to append add-on fields to subcategory checkboxes.

Note that the form will append the parent category tag to the submitted tags if any subcategory is selected.

Any parent category with no subcategories will show a faux subcategory with the same name, id as the parent.

<img width="200" alt="Screen Shot 2020-06-10 at 00 25 07" src="https://user-images.githubusercontent.com/8330/84228017-e2410000-aab3-11ea-913b-15236209b610.png">
