### PR TITLE
Redesign respond workflow

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -15,6 +15,9 @@ class AdminController < ApplicationController
     @community_resources_pending_count = CommunityResource.pending_review.length
   end
 
+  def dispatch_steps
+  end
+
   def glossary
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,14 +8,15 @@ module ApplicationHelper
     "<span class='#{ boolean ? "fa fa-check-circle has-text-success" : "fa fa-ban" }'></span>".html_safe
   end
 
-  def edit_button(resource, button_text="Edit", icon_class="fa fa-edit", button_text_class=nil, button_class=nil, params={})
+  def edit_button(resource, button_text="Edit", icon_class="fa fa-edit",
+                  button_text_class=nil, button_class=nil, params={}, button_title=nil, path=nil)
     if resource
       resource_class = resource.class
       if resource_class.superclass != ApplicationRecord
         resource = resource.becomes(resource.class.superclass)
       end
-      link_to(edit_polymorphic_path(resource, params),
-              title: action_name || button_text + " " + controller_path || resource_class.to_s,
+      link_to(path.present? ? "#{path}?#{params}" : edit_polymorphic_path(resource, params),
+              title: button_title || (action_name || button_text + " " + controller_path || resource_class.to_s),
               class: "button edit-button #{button_class}") do
         "<span class='#{icon_class}'></span><span class='#{button_text_class}' style='padding-left: 0.25em'> #{button_text}</span>".html_safe
       end
@@ -31,6 +32,18 @@ module ApplicationHelper
             title: action_name || button_text + " " + controller_path || resource_class.to_s,
             class: "button show-button #{margin_class}") do
       "<span class='#{icon_class}'></span><span class='#{button_text_class}' style='padding-left: 0.25em'> #{button_text}</span>".html_safe
+    end
+  end
+
+  def triage_button(resource)
+    resource_class = resource.class
+    if resource_class != Person && (resource_class.superclass != ApplicationRecord)
+      resource = resource.becomes(resource.class.superclass)
+    end
+    link_to(triage_contribution_path(resource),
+            title: "Triage/edit",
+            class: "button triage-button is-primary") do
+      "<span class='fa fa-edit'></span><span style='padding-left: 0.25em'> Triage/edit</span>".html_safe
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -35,7 +35,7 @@ class Person < ApplicationRecord
   end
 
   def match_history
-    "#{asks.matched.length}/#{asks.length} asks matched, #{offers.matched.length}/#{offers.length} offers matched"
+    "#{asks.matched.length} out of #{asks.length} Asks matched, and, #{offers.matched.length} out of #{offers.length} Offers matched"
   end
 
   def all_tags_unique

--- a/app/views/admin/dispatch_steps.html.erb
+++ b/app/views/admin/dispatch_steps.html.erb
@@ -1,0 +1,39 @@
+<div class="columns">
+  <div class="column is-12">
+    <div class="title">Dispatch Steps</div>
+    <hr>
+  </div>
+</div>
+
+<div class="row columns">
+  <div class="columns column is-12">
+    <div class="column is-12">
+      <ol>
+        <li>
+          View unmatched <%= link_to "Contributions", contributions_path %>
+          <ul style="padding-left: 2em;">
+            <ul style="list-style-type: circle !important">
+              <li>Select a Contribution (Ask or Offer) and click <%= link_to "Respond", respond_contribution_path(Ask.last) %></li>
+              <li>Triage (edit details), if needed</li>
+              <li>Create tentative Match</li>
+              <li>Log Communications w pair</li>
+              <li>Edit Match status</li>
+              <li>Save Contribution</li>
+            </ul>
+          </ul>
+        </li>
+
+        <li>
+          View <%= link_to "Matches", matches_path %> index
+          <ul style="padding-left: 2em;">
+            <ul style="list-style-type: circle !important">
+              <li>Filter to find Matches that "Need followup"</li>
+              <li>Edit/log Communications</li>
+              <li>Connect/claim, if desired</li>
+            </ul>
+          </ul>
+        </li>
+      </ol>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/landing_page.html.erb
+++ b/app/views/admin/landing_page.html.erb
@@ -45,6 +45,8 @@
     <div class="column is-4">
       <%= link_to "Glossary!", glossary_admin_path %>
       <br>
+      <%= link_to "Dispatch steps", dispatch_steps_admin_path %>
+      <br>
       <%= link_to "Yearbook", yearbook_admin_path %>
       <br>
       <%= link_to "Org chart", org_chart_path %>

--- a/app/views/admin/volunteer_admin.html.erb
+++ b/app/views/admin/volunteer_admin.html.erb
@@ -2,6 +2,10 @@
 
 <%= link_to "Manage User Account permissions", users_path(position_type: "Volunteer") %>
 <br>
+<%= link_to "Add Shifts", shifts_path %>
+<br>
+<%= link_to "Review Dispatch steps", dispatch_steps_admin_path %>
+<br>
 <%= link_to "View training status (NOT IMPLEMENTED)", people_path(position_type: "Volunteer")  %>
 <br>
 <%= link_to "Filter by workload (NOT IMPLEMENTED)", people_path(position_type: "Volunteer")  %>

--- a/app/views/communication_logs/_form.html.erb
+++ b/app/views/communication_logs/_form.html.erb
@@ -29,6 +29,7 @@
       <%= f.label :body, class: "label" %>
       <%= f.object.body&.html_safe || "-- Empty --" %>
     <% else %>
+      <%= f.input :subject, label: "Summary/title (45 chars)", input_html: { maxlength: 45 } %>
       <%= f.input :body, as: :text,
                   label: "Notes (if re a match, use this for notes re ONE CATEGORY only! create a new <a href='/asks/new?person_id=#{@person&.id}'> Ask
                     </a> or <a href='/offers/new?person_id=#{@person&.id}'> Offer

--- a/app/views/contributions/respond.html.erb
+++ b/app/views/contributions/respond.html.erb
@@ -1,77 +1,107 @@
 <% person = @contribution.person %>
 
-<div class="title is-5">Respond to contribution:    <%= link_to "go to Contributions page", contributions_path %></div>
-
-<div class="contribution">
-  <div class="summary">
-      <span class="title is-1"><span class="<%= @contribution.icon_class %>"></span> <%= @contribution&.type %>: <%= @contribution&.all_tags_to_s&.upcase %>
-        </span> <%#= edit_button(@contribution, "Edit") %><!-- # TODO - add update action back in once we have moved controllers-->
-  </div>
-  <%= "<br>".html_safe if @contribution.title.present? || @contribution.description.present? %>
-  <div class="subtitle is-5"><%= @contribution.title %></div>
-  <div class="description"><%= @contribution.description %></div>
+<div class="title is-5">
+  Respond to Contribution: <%= link_to "go to Contributions page", contributions_path %>
+  <br>
+  <span class="subtitle is-7 is-italic">(1. Triage (or log Communication), then 2. Add tentative Match)</span>
 </div>
 
+<br><br>
 <div class="columns">
-  <div class="column">
-    <hr>
+  <div class="contribution column">
+    <div class="summary">
+      <strong>Contribution:</strong>
+      <br>
+      <span class="title is-1">
+        <span class="<%= @contribution.icon_class %>"></span> <%= @contribution&.type %>: <%= @contribution&.all_tags_to_s&.upcase %>
+      </span>
+        <%#= edit(@contribution) %><!-- # TODO - add update action back in once we have moved controllers-->
+    </div>
+    <div class="created_at">Created on <%= shorthand_display(@contribution.created_at) %></div>
+    <%= "<br>".html_safe if @contribution.title.present? || @contribution.description.present? %>
+    <div class="subtitle is-5"><%= @contribution.title %></div>
+    <div class="description"><%= @contribution.description %></div>
+    <br><br>
+    <%= triage_button(@contribution) %>
+    <br><br>
+    <% if @contribution.ask? %>
+      <%= render "layouts/view_add_new_button", button_text: "Add tentative Match", table_name: "matches", new_params: "receiver_id=#{@contribution.id}&receiver_type=Ask" %>
+      <%= link_to("Find Match [TBD]",
+                  match_listing_path(@contribution, receiver_id: @contribution.id, receiver_type: "Ask"),
+                  class: "button") if params[:admin] %>
+    <% elsif @contribution.offer? %>
+      <%= render "layouts/view_add_new_button", button_text: "Add tentative Match", table_name: "matches", new_params: "provider_id=#{@contribution.id}&provider_type=Offer" %>
+      <%= link_to("Find Match [TBD]",
+                  match_listing_path(@contribution, provider_id: @contribution.id, provider_type: "Offer"),
+                  class: "button") if params[:admin] %>
+    <% end %>
+  </div>
+  <div class="person column">
     <div class="contact-info">
       <strong>Created by:</strong>
       <br>
       <%= show_button(person, person&.name, "fa fa-user-circle", "title is-5", nil, contribution_id: @contribution.id) %>
-      <br>
+      <br><br>
       <strong>Preferred contact info:</strong>
       <br>
       <span class="<%= person.preferred_contact_method.icon_class %>"></span>
       <span class="subtitle is-5"><%= person.preferred_contact_info %></span>
     </div>
-    <hr>
-    <% if @contribution.ask? %>
-      <%= link_to("Find Match [TBD]",
-                  match_listing_path(@contribution, receiver_id: @contribution.id, receiver_type: "Ask"),
-                  class: "button") %>
-      <%= render "layouts/view_add_new_button", button_text: "Add tentative Match", table_name: "matches", new_params: "receiver_id=#{@contribution.id}&receiver_type=Ask" %>
-    <% elsif @contribution.offer? %>
-      <%= link_to("Find Match [TBD]",
-                  match_listing_path(@contribution, provider_id: @contribution.id, provider_type: "Offer"),
-                  class: "button") %>
-      <%= render "layouts/view_add_new_button", button_text: "Add tentative Match", table_name: "matches", new_params: "provider_id=#{@contribution.id}&provider_type=Offer" %>
-    <% end %>
-    <hr>
-    <strong><%= "#{person.name}'s " %> all-time Match totals:</strong>
-    <br>
-    <span><%= person.match_history %></span>
-    <hr>
-    <strong>Match history **for this <%= @contribution.type %> (<%= @contribution.all_tags_to_s.upcase %>)**:</strong>
-    <br>
-    <% match_assn_name = @contribution.ask? ? "matches_as_receiver" : "matches_as_provider" %>
-    <% matches_for_this_contribution = @contribution.public_send(match_assn_name) %>
-    <% if matches_for_this_contribution.any? %>
-      <% matches_for_this_contribution.order(created_at: :desc).each do |match| %>
-        <%= edit_button(match, "(#{shorthand_display(match.created_at)}) #{match.short_name}") %>
+
+    <div class="all-time-match-info">
+      <br><br>
+      <strong>Participation summary:</strong>
+      <br>
+      <span><%= person.match_history %></span>
+
+      <br><br>
+      <% match_assn_name = @contribution.ask? ? "matches_as_receiver" : "matches_as_provider" %>
+      <% matches_for_this_contribution = @contribution.public_send(match_assn_name) %>
+      <% if matches_for_this_contribution.any? %>
+        <strong>Match history for <%= @contribution.type %> (<%= @contribution.all_tags_to_s.upcase %>, <%= shorthand_display(@contribution.created_at) %>):</strong>
         <br>
+        <% matches_for_this_contribution.order(created_at: :desc).each do |match| %>
+          <%= edit_button(match, "#{shorthand_display(match.created_at)} #{match.short_name}", nil, nil, {}, "View Match") %>
+          <br>
+        <% end %>
+        <br><br>
       <% end %>
-    <% else %>
-      (No matches)
-    <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="columns">
+  <div class="column">
+    <hr>
+    <div class="title is-5">COMMUNICATION HISTORY:</div>
+    <hr>
+    <%= render "matches/communication_log_quick_buttons", person: person %>
+    <hr>
+    <%= render "matches/communication_history", person: person %>
+  </div>
+  <div class="column">
+    <hr>
+    <div class="title is-5">OTHER CONTRIBUTION AND MATCH INFO:</div>
 
     <% Contribution::TYPES.each do |type| %>
-      <% contribution_assn = type.to_s.pluralize.downcase %>
       <hr>
-      <strong><%= "#{person.name}'s " %> other unmatched <%= contribution_assn %>:</strong>
+      <% contribution_assn = type.to_s.pluralize.downcase %>
+      <strong><%= "#{person.name}'s " %> other unmatched <%= contribution_assn.titleize %>:</strong>
       <br>
       <% if @contribution.person.public_send(contribution_assn).unmatched.
           where.not("listings.id = ?", @contribution.id).any? %>
-            <% @contribution.person.public_send(contribution_assn).unmatched.
-                where.not("listings.id = ?", @contribution.id).
-                order(:created_at).each do |contribution| %>
-                  <%= link_to("(#{shorthand_display(contribution.created_at)}) #{contribution.all_tags_to_s.upcase}",
-                              respond_contribution_path(contribution,
-                                                        contribution_type: type), class: "button") %>
+        <% @contribution.person.public_send(contribution_assn).unmatched.
+            where.not("listings.id = ?", @contribution.id).
+            order(created_at: :desc).each do |contribution| %>
+          <%= link_to("<span class='#{contribution.icon_class}'></span>  #{
+                       shorthand_display(contribution.created_at)} #{contribution.all_tags_to_s.upcase}".html_safe,
+                       respond_contribution_path(contribution,
+                                                 contribution_type: type),
+                      class: "button", title: "View Match") %>
           <br>
         <% end %>
       <% end %>
-     <%= "<br>".html_safe if contribution_assn == Contribution::TYPES.last %>
+      <%= "<br>".html_safe if contribution_assn == Contribution::TYPES.last %>
     <% end %>
 
     <hr>
@@ -79,25 +109,19 @@
     <strong><%= "#{person.name}'s " %> Match history:</strong>
     <br>
     <% no_matches_comments = [] %>
-    <% @contribution.person.listings.where.not(id: @contribution).order(:type).each do |listing| %>
+    <% @contribution.person.listings.where.not(id: @contribution).order(created_at: :desc).each do |listing| %>
       <% match_assn_name = listing.ask? ? "matches_as_receiver" : "matches_as_provider" %>
       <% other_matches = listing.public_send(match_assn_name) %>
-        <% if other_matches.any? %>
-          <% listing.public_send(match_assn_name).order(created_at: :desc).each do |match| %>
-            <%= edit_button(match, "(#{shorthand_display(match.created_at)}) #{match.short_name}") %>
-            <br>
-          <% end %>
-        <% no_matches_comments << "has_matches" %>
-        <% else %>
-          <% no_matches_comments << "(No other matches)" %>
+      <% if other_matches.any? %>
+        <% listing.public_send(match_assn_name).order(created_at: :desc).each do |match| %>
+          <%= edit_button(match, "#{shorthand_display(match.created_at)} #{match.short_name}", listing.icon_class, nil, nil, {}, "View Match") %>
+          <br>
         <% end %>
+        <% no_matches_comments << "has_matches" %>
+      <% else %>
+        <% no_matches_comments << "(No other matches)" %>
+      <% end %>
     <% end %>
     <%= no_matches_comments.uniq.join if no_matches_comments.uniq.length == 1 %>
-  </div>
-  <div class="column">
-    <hr>
-    <%= render "matches/communication_log_quick_buttons", person: person %>
-    <hr>
-    <%= render "matches/communication_history", person: person %>
   </div>
 </div>

--- a/app/views/contributions/respond.html.erb
+++ b/app/views/contributions/respond.html.erb
@@ -3,7 +3,7 @@
 <div class="title is-5">
   Respond to Contribution: <%= link_to "go to Contributions page", contributions_path %>
   <br>
-  <span class="subtitle is-7 is-italic">(1. Triage (or log Communication), then 2. Add tentative Match)</span>
+  <span class="subtitle is-7 is-italic"><%= link_to "(1. Triage (or log Communication), then 2. Add tentative Match)", dispatch_steps_admin_path %></span>
 </div>
 
 <br><br>

--- a/app/views/contributions/triage.html.erb
+++ b/app/views/contributions/triage.html.erb
@@ -1,0 +1,18 @@
+<%= render "layouts/view_header", resource: @contribution,
+           page_title: "Update #{@contribution.name}", human_name: @contribution.type %>
+<br><br>
+<%= simple_form_for @contribution, url: triage_contribution_path(@contribution) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :title, label: "Summary/title (45 chars)", input_html: { maxlength: 45 } %>
+    <%= f.input :description,
+                label: "Notes (for THIS CATEGORY only! create a new <a href='/asks/new?person_id=#{@contribution.person&.id}'> Ask
+                  </a> or <a href='/offers/new?person_id=#{@contribution.person&.id}'> Offer
+                  </a>, as needed, but save this form first!)".html_safe %>
+  </div>
+
+  <%= f.button :submit,
+               "Update #{@contribution.type}",
+               class: "button mt-1 is-primary" %>
+<% end %>

--- a/app/views/matches/_communication_history.html.erb
+++ b/app/views/matches/_communication_history.html.erb
@@ -1,15 +1,30 @@
-<strong>Communication history with <%= person&.name %><%= " re this match" if @match.present? %>:</strong>
-<br><br>
 <ul>
-  <% communication_logs = @communication_logs.where(person: person) %>
-  <% if communication_logs.any? %>
-    <% communication_logs.order(sent_at: :desc).each do |log| %>
+  <strong>Communications with <%= person&.name %><%= " re this Match" if @match.present? %>:</strong>
+  <br><br>
+  <% match_communication_logs = @communication_logs.where(person: person) %>
+  <% pre_match_communication_logs = person.communication_logs.where(match_id: nil) %>
+
+  <% if match_communication_logs.any? %>
+    <% match_communication_logs.order(sent_at: :desc).each do |log| %>
       <% delivery_status = " [#{log.delivery_status}] " %>
       <% icon = "<span class='#{log.needs_follow_up? ? 'fa fa-exclamation-circle has-text-warning' : 'fa fa-circle has-text-white'}'></span>" %>
       <% short_name = "#{icon} #{shorthand_display(log.sent_at)}#{delivery_status} - #{log.subject}" %>
-      <li><%= edit_button(log, short_name, log.delivery_method.icon_class || "fa fa-telegram") %></li>
+      <li><%= edit_button(log, short_name, log.delivery_method.icon_class || "fa fa-telegram", nil, nil, contribution_id: @contribution&.id) %></li>
     <% end %>
-  <% else %>
+  <% elsif pre_match_communication_logs.none? %>
     (No communications are logged)
+  <% end %>
+
+  <% if @match.present? %>
+    <strong>Other Communications with <%= person&.name %>:</strong>
+    <br><br>
+    <% if match_communication_logs.any? %>
+      <% pre_match_communication_logs.order(sent_at: :desc).each do |log| %>
+        <% delivery_status = " [#{log.delivery_status}] " %>
+        <% icon = "<span class='#{log.needs_follow_up? ? 'fa fa-exclamation-circle has-text-warning' : 'fa fa-circle has-text-white'}'></span>" %>
+        <% short_name = "#{icon} #{shorthand_display(log.sent_at)}#{delivery_status} - #{log.subject}" %>
+        <li><%= edit_button(log, short_name, log.delivery_method.icon_class || "fa fa-telegram", nil, nil, contribution_id: @contribution&.id) %></li>
+      <% end %>
+    <% end %>
   <% end %>
 </ul>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -57,10 +57,11 @@
             </div>
           </div>
 
-          <!--communications with person who is NOT currently associated-->
+          <!--communications with anyone who is NOT currently associated-->
           <% prior_connection_communication_logs = @communication_logs.where.not(person: [provider_person, receiver_person]) %>
           <% if prior_connection_communication_logs.any? %>
-            <div class="has-text-weight-bold">Communication history with other people previously connected to this match:</div>
+            <hr>
+            <div class="has-text-weight-bold">Communication with others previously connected to this Match:</div>
             <br>
             <ul>
               <% prior_connection_communication_logs.order(sent_at: :desc).where(match: @match).each do |log| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
   resources :contributions, only: [:index] do
     member do
       get "/respond", to: "contributions#respond", as: "respond"
+      get "/triage", to: "contributions#triage", as: "triage"
+      patch "/triage", to: "contributions#triage_update"
+      post "/triage", to: "contributions#triage_update"
     end
   end
   resources :custom_form_questions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,9 @@ Rails.application.routes.draw do
 
   get "/admin",                    to: "admin#landing_page",    as: "landing_page_admin"
   get "/admin/volunteers",         to: "admin#volunteer_admin", as: "volunteer_admin"
-  get "/glossary",                 to: "admin#glossary",        as: "glossary_admin"
-  get "/yearbook",                 to: "admin#yearbook",        as: "yearbook_admin"
+  get "/admin/dispatch",           to: "admin#dispatch_steps",  as: "dispatch_steps_admin"
+  get "/admin/glossary",           to: "admin#glossary",        as: "glossary_admin"
+  get "/admin/yearbook",           to: "admin#yearbook",        as: "yearbook_admin"
 
   get "/public",                   to: "public_pages#landing_page",        as: "landing_page_public"
   get "/about",                    to: "public_pages#about",               as: "about_public"


### PR DESCRIPTION
After several trainings, it's clear the "Dispatch Steps" and associated pages needed to be a bit clearer.

- Respond page now has a link to Dispatch Steps at top
- Communications log is now on LEFT so it will match what's expected for an Ask once you transition to "Add a tentative Match" (Respond will most often be used for Ask workflow)
- Added "triage" action to ContributionsController to handle title/description updates (this may or may not be replaced by Submission Edit)
- Moved Communications history and Other Contributions & Matches almost below the fold
- Change some partials and helpers to improve design/UX
- Change admin endpoint urls to include admin prefix

