### PR TITLE
Add form_admin and cleanup views

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -18,6 +18,9 @@ class AdminController < ApplicationController
   def dispatch_steps
   end
 
+  def form_admin
+  end
+
   def glossary
   end
 

--- a/app/controllers/form_questions_controller.rb
+++ b/app/controllers/form_questions_controller.rb
@@ -51,7 +51,7 @@ class FormQuestionsController < ApplicationController
   end
 
   def set_form_dropdowns
-    @custom_form_question_questions = CustomFormQuestionQuestion.all
+    @custom_form_question_questions = CustomFormQuestion.all
     @form_questions = FormQuestion.all
   end
 

--- a/app/models/custom_form_question.rb
+++ b/app/models/custom_form_question.rb
@@ -1,8 +1,8 @@
 class CustomFormQuestion < ApplicationRecord
   extend Mobility
-  translates :name
+  translates :name, type: :string
   translates :option_list, type: :string # if this is json, ok to say string here?
-  translates :hint_text
+  translates :hint_text, type: :string
 
   has_many :submission_responses
   has_many :form_questions

--- a/app/views/admin/form_admin.html.erb
+++ b/app/views/admin/form_admin.html.erb
@@ -1,0 +1,11 @@
+<div class="title is-3">Forms admin</div>
+
+<%= link_to "Forms", forms_path %>
+<br>
+<%= link_to "Custom Form Questions", custom_form_questions_path %>
+<br>
+<%= link_to "Form Questions", form_questions_path  %>
+<br>
+
+<br>
+<%= link_to "Admin home", landing_page_admin_path %>

--- a/app/views/admin/landing_page.html.erb
+++ b/app/views/admin/landing_page.html.erb
@@ -118,7 +118,9 @@
     <% admin_buttons_list_3 = [
         ["categories"],
         ["contact_methods", "Contact Methods"],
-        ["custom_form_questions", "Form Questions"],
+        ["forms", "Forms"],
+        ["custom_form_questions", "Custom Form Questions"],
+        ["form_questions", "Form-Questions"],
         ["location_types"],
         ["mobility_string_translations", "Translations"],
         ["service_areas", "Service areas"],

--- a/app/views/form_questions/edit.html.erb
+++ b/app/views/form_questions/edit.html.erb
@@ -1,6 +1,1 @@
-<h1>Editing Form Question</h1>
-
-<%= render 'form', form_question: @form_question %>
-
-<%= link_to 'Show', @form_question %> |
-<%= link_to 'Back', form_questions_path %>
+<%= render "layouts/view_header", resource: @form_question %>

--- a/app/views/form_questions/index.html.erb
+++ b/app/views/form_questions/index.html.erb
@@ -1,29 +1,21 @@
-<div class="columns is-marginless">
-  <div class="column is-9">
-    <h1 class="title">Form Questions</h1>
-    <br>
-  </div>
-  <div class="column is-2">
-    <%= render "layouts/view_add_new_button", table_name: form_questions %>
-  </div>
-</div>
+<%= render "layouts/view_header", resource: @form_questions.first %>
 
 <table class="table table-hover table-curved table-condensed">
   <thead>
-  <tr>
-          <th>Form</th>
-          <th>Custom form question</th>
-        <th>Edit</th>
-  </tr>
+    <tr>
+      <th>Form</th>
+      <th>Custom form question</th>
+      <th>Edit</th>
+    </tr>
   </thead>
 
   <tbody>
-  <% @form_questions.each do |form_question| %>
-    <tr>
-              <td><%= form_question.form_id %></td>
-              <td><%= form_question.custom_form_question_id %></td>
-            <td><%= link_to 'Edit', edit_form_question_path(form_question) %></td>
-    </tr>
-  <% end %>
+    <% @form_questions.each do |form_question| %>
+      <tr>
+        <td><%= form_question.form.name %></td>
+        <td><%= form_question.custom_form_question.name %></td>
+        <td><%= edit_button(form_question) %></td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/form_questions/new.html.erb
+++ b/app/views/form_questions/new.html.erb
@@ -1,5 +1,1 @@
-<h1>New Form Question</h1>
-
-<%= render 'form', form_question: @form_question %>
-
-<%= link_to 'Back', form_questions_path %>
+<%= render "layouts/view_header", resource: @form_question %>

--- a/app/views/form_questions/show.html.erb
+++ b/app/views/form_questions/show.html.erb
@@ -1,14 +1,14 @@
-<p id="notice"><%= notice %></p>
+<%= render "layouts/view_header", resource: @form_question %>
 
 <p>
   <strong>Form:</strong>
-  <%= @form_question.form_id %>
+  <%= @form_question.form.name %>
 </p>
 
 <p>
   <strong>Custom form question:</strong>
-  <%= @form_question.custom_form_question_id %>
+  <%= @form_question.custom_form_question.name %>
 </p>
 
-<%= link_to 'Edit', edit_form_question_path(@form_question) %> |
+<%= edit_button(@form_question) %>
 <%= link_to 'Back', form_questions_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   get "/admin",                    to: "admin#landing_page",    as: "landing_page_admin"
+  get "/admin/forms",              to: "admin#form_admin",      as: "form_admin"
   get "/admin/volunteers",         to: "admin#volunteer_admin", as: "volunteer_admin"
   get "/admin/dispatch",           to: "admin#dispatch_steps",  as: "dispatch_steps_admin"
   get "/admin/glossary",           to: "admin#glossary",        as: "glossary_admin"


### PR DESCRIPTION
There wasn't a way to access the form mgmt pieces of the app before
- Added indexes to admin_landing
- Created form_admin page where form-related indexes are
- Later prob want to add stats re which forms are live, how many responses, etc
- Added explicity type: :string for translations
- Update form-related views w app conventions like view_header