### PR TITLE
Rename scope on CustomFormQuestion

### DIFF
--- a/app/models/custom_form_question.rb
+++ b/app/models/custom_form_question.rb
@@ -25,6 +25,6 @@ class CustomFormQuestion < ApplicationRecord
       "youtube_video_id" => "string_response",
   }
 
-  scope :name, ->(name) { joins(:mobility_string_translations).
+  scope :translated_name, ->(name) { joins(:mobility_string_translations).
       where("LOWER(mobility_string_translations.name) = ?", name) }
 end


### PR DESCRIPTION
Heroku yelled at me for having a scope named 'name' on CustomFormQuestion