### PR TITLE
Improve readme setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ yarn-debug.log*
 .idea/sshConfigs.xml
 .idea/vcs.xml
 .idea/webServers.xml
+.idea/*
+*.iml
 
 # Ignore VSCode files
 .vscode*

--- a/ORIENTATION.md
+++ b/ORIENTATION.md
@@ -19,7 +19,7 @@ Our team community norm: timing is difficult for everyone given the current unce
 
 * The groups we’re working with are "people first," and believe strongly in not referring to users as "offerers" or "askers," but instead the idea of seeing the whole person and their membership in the community as priority.
 
-## Holisitc approach
+## Holistic approach
 * Existing platforms (e.g. marketplaces and even mutual aid specific ones) seem to focus on the listings feature exclusively, whereas we want to offer integration with mutual aid group operations (administration, pod mapping, resource sharing, fewer logins, central point of access granted/denied, etc)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Then, to run the app locally,
 ```
 $ bundle install
 $ yarn install
-$ SYSTEM_EMAIL=example@example.com SYSTEM_PASSWORD=12345678 rake db:setup
+$ # in .env, add SYSTEM_EMAIL and SYSTEM_PASSWORD, or:
+$ SYSTEM_EMAIL=example@example.com SYSTEM_PASSWORD=12345678 rake db:rebuild_and_seed_dev
 $ rails s # or, rails s -p 9000 (or whatever port you want to use that's not the default 3000)
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Then, to run the app locally,
 ```
 $ bundle install
 $ yarn install
-$ rake dev:setup
+$ SYSTEM_EMAIL=example@example.com SYSTEM_PASSWORD=12345678 rake db:setup
 $ rails s # or, rails s -p 9000 (or whatever port you want to use that's not the default 3000)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/maebeale/mutual-aid.svg?style=svg)](https://circleci.com/gh/maebeale/mutual-aid)
+
 # Who we are:
 
 We are devs committed to making mutual aid manageable and longstanding, so as to build, support, and strengthen resilient communities.


### PR DESCRIPTION
Just a minor change from getting myself setup- `rake dev:setup` doesn't exist but `rake db:setup` does so I assume that's what goes here. The env variables are needed to get `db:setup` to run because otherwise `seed.rb` fails. 

I added the gitignore lines because of my local dev setup

Add a badge for the CI build to make it easier to find on the main page