### PR TITLE
Add a stylesheet_pack_tag to include vue styles in prod

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,4 +7,5 @@
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
 </head>


### PR DESCRIPTION
Vue styles (currently limited to TileListItem.vue) aren't included in the main assets bundle, so we need to add a `stylesheets_pack_tag` to the head in order to load them from `public/packs/css`