### PR TITLE
Specify node version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mutualaid",
   "private": true,
   "version": "0.2.2",
+  "engines": {
+    "node": "12.x"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@rails/ujs": "^6.0.0",


### PR DESCRIPTION
Heroku expects this to be set, to determine which version of node to use. Currently this is the default anyway, but we should probably be explicit so that nothing changes if they update the default.