### PR TITLE
Improve contributions readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Enhancements
+* #558 Improve contributions readability (remove labels, change prominence of created_at values)
+
 ## [0.2.2] - 2020-06-27
 
 ### Breaking changes

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -23,13 +23,13 @@
       </div>
 
       <div class="text">
+        <div>
+          <small><time :datetime="createdAtDate.toISOString()">{{ createdAtDate.toLocaleDateString() }} {{ createdAtDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) }}</time></small>
+        </div>
         <h5 class="has-text-weight-bold">{{ title }}</h5>
         <p>{{ description }}</p>
         <div v-if="service_area" class="has-text-grey-lighter">
-          <small>Service area:</small> {{ service_area.name }}
-        </div>
-        <div class="has-text-grey-lighter">
-          <small>Submitted: <time :datetime="createdAtDate.toISOString()">{{ createdAtDate.toLocaleDateString() }} {{ createdAtDate.toLocaleTimeString() }}</time></small>
+          {{ service_area.name }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
* Move time to top of text section
* Make text black
* Shorten time display (don't need milliseconds 00:00:00)
* Remove 'Submitted: ' and 'Service Area:' text from cards 
* update CHANGELOG

After:
<img width="250" alt="Screen Shot 2020-06-30 at 1 07 33 PM" src="https://user-images.githubusercontent.com/7607813/86155665-c210c980-bad2-11ea-81ab-c6c7ec3a8ae5.png">

Before:
<img width="228" alt="Screen Shot 2020-06-30 at 1 07 47 PM" src="https://user-images.githubusercontent.com/7607813/86155660-bf15d900-bad2-11ea-838f-586c9becab01.png">

