### PR TITLE
Display tags independently on Matches index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 ### Enhancements
 * #558 Improve contributions readability (remove labels, change prominence of created_at values)
-* #565 Remove tag class until Listings have one category per Listing
+
+### Bugfixes
+* Display tags independently on Matches index (to fix nowrap issue) #565
 
 ## [0.2.2] - 2020-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Enhancements
 * #558 Improve contributions readability (remove labels, change prominence of created_at values)
+* #565 Remove tag class until Listings have one category per Listing
 
 ## [0.2.2] - 2020-06-27
 

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -27,11 +27,13 @@
         <td><%= shorthand_display(match.created_at) %></td>
         <td><%= shorthand_display(match.updated_at) %></td>
         <td>
-          <span class="tag is-info is-light has-text-weight-bold"><%= match.receiver&.all_tags_to_s.upcase %></span>
+          <!-- # TODO - add 'tag' class back in once Listings are one category per -->
+          <span class="is-info is-light has-text-weight-bold"><%= match.receiver&.all_tags_to_s.upcase %></span>
           <br>
           <%= match.receiver&.person&.name %></td>
         <td>
-          <span class="tag is-info is-light has-text-weight-bold"><%= match.provider&.all_tags_to_s.upcase %></span>
+          <!--  # TODO - add 'tag' class back in once Listings are one category per -->
+          <span class="is-info is-light has-text-weight-bold"><%= match.provider&.all_tags_to_s.upcase %></span>
           <br>
           <%= match.provider&.person&.name %></td>
         <td><%= match.status.titleize %></td>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -27,13 +27,15 @@
         <td><%= shorthand_display(match.created_at) %></td>
         <td><%= shorthand_display(match.updated_at) %></td>
         <td>
-          <!-- # TODO - add 'tag' class back in once Listings are one category per -->
-          <span class="is-info is-light has-text-weight-bold"><%= match.receiver&.all_tags_to_s.upcase %></span>
+          <% match.receiver&.all_tags_unique&.each do |tag_name| %>
+            <span class="tag is-info is-light has-text-weight-bold"><%= tag_name.upcase %></span>
+          <% end %>
           <br>
           <%= match.receiver&.person&.name %></td>
         <td>
-          <!--  # TODO - add 'tag' class back in once Listings are one category per -->
-          <span class="is-info is-light has-text-weight-bold"><%= match.provider&.all_tags_to_s.upcase %></span>
+          <% match.provider&.all_tags_unique&.each do |tag_name| %>
+            <span class="tag is-info is-light has-text-weight-bold"><%= tag_name.upcase %></span>
+          <% end %>
           <br>
           <%= match.provider&.person&.name %></td>
         <td><%= match.status.titleize %></td>


### PR DESCRIPTION
There was a bug in Matches index where having a bunch of tags was causing table to be too wide
Now iterating over tag list and displaying each tag independently
(This will be less of an issue after Listings only have one category per tag)

Before:
<img width="1436" alt="Screen Shot 2020-07-05 at 3 00 40 PM" src="https://user-images.githubusercontent.com/7607813/86540272-e48b5400-bed1-11ea-80ae-ce6b2e9a0d67.png">

After:
<img width="1408" alt="Screen Shot 2020-07-05 at 3 10 47 PM" src="https://user-images.githubusercontent.com/7607813/86540277-ece38f00-bed1-11ea-913f-f16603a38f6a.png">


