### PR TITLE
Add create Ask and Offer buttons to submissions

### DIFF
--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -1,3 +1,9 @@
+<style>
+  .field.is-horizontal {
+    display: inline-block;
+  }
+</style>
+
 <%= simple_form_for @community_resource do |f| %>
   <% if f.object.errors.any? %>
     <div id="error_explanation">

--- a/app/views/listings/_form.html.erb
+++ b/app/views/listings/_form.html.erb
@@ -1,3 +1,8 @@
+<style>
+  .field.is-horizontal {
+    display: inline-block;
+  }
+</style>
 <%= simple_form_for @listing do |f| %>
   <%= f.error_notification %>
 
@@ -8,7 +13,7 @@
                   </a> or <a href='/offers/new?person_id=#{@person&.id}'> Offer
                   </a>, as needed, but save this form first!)".html_safe %>
     <div class="field is-grouped">
-      <%= f.input :type, as: :select, collection: ["Ask", "Offer"] %>
+      <%= f.input :type, as: :select, collection: ["Ask", "Offer"], selected: action_name == "new" ? params[:type] : f.object.type %>
       <% if action_name == 'new' %>
         <%= f.hidden_field :state, value: f.object.state || "received" %>
       <% else %>
@@ -16,10 +21,10 @@
       <% end %>
     </div>
     <%= f.input :tag_list, as: :check_boxes, collection: @available_tags %>
-    <%= f.association :person, include_blank: true %>
-    <%= f.association :service_area, include_blank: true %>
-    <%= f.association :location, include_blank: true %>
-    <%= (f.association :submission, include_blank: true) if current_user.sys_admin_role? %>
+    <%= f.association :person, include_blank: true, selected: params[:person_id] %>
+    <%= f.association :service_area, include_blank: true, selected: params[:service_area_id] %>
+    <%= f.association :location, include_blank: true, selected: params[:location_id] %>
+    <%= (f.association :submission, include_blank: true, selected: params[:submission_id]) if current_user.sys_admin_role? || params[:submission_id] %>
     <%= f.input :inexhaustible, as: :radio_buttons %>
   </div>
 

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -44,6 +44,14 @@
     <%= show_button(listing, "View " + listing.name, listing.icon_class) %>
     <br>
   <% end %>
+  <%= link_to "Add Offer", new_listing_path(submission_id: @submission.id, person_id: @submission.person_id,
+                                            service_area_id: @submission.service_area_id,
+                                            location_id: @submission.person.location_id,
+                                            type: "Offer") %>
+  <%= link_to "Add Ask", new_listing_path(submission_id: @submission.id, person_id: @submission.person_id,
+                                          service_area_id: @submission.service_area_id,
+                                          location_id: @submission.person.location_id,
+                                          type: "Ask") %>
 </div>
 <hr>
 <div>


### PR DESCRIPTION
- Some imported data will need manual Listing creation. This allows users to easily add associated Listings.
- Added style override for tag_lists that are too long

Before:
<img width="528" alt="Screen Shot 2020-07-16 at 5 49 55 PM" src="https://user-images.githubusercontent.com/7607813/87726332-ce607c00-c78c-11ea-97f1-c48b42d1161d.png">

After:
<img width="478" alt="Screen Shot 2020-07-16 at 5 49 36 PM" src="https://user-images.githubusercontent.com/7607813/87726340-d15b6c80-c78c-11ea-80c6-78e49f89b8d6.png">
