### PR TITLE
Implement in-memory ActiveJob to background response import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Enhancements
 * Update submissions importer #577 & #579
-* Add UI to upload submission responses for import #589
+* Add UI to upload submission responses for import #589, #585
 * Improve tag_list checkbox UI #579
 * Add +Listing buttons to Submission #578
 

--- a/app/controllers/submission_response_imports_controller.rb
+++ b/app/controllers/submission_response_imports_controller.rb
@@ -5,8 +5,14 @@ class SubmissionResponseImportsController < ApplicationController
 
   def create
     uploaded_file = params[:submission_response_import]
-    importer = Importers::SubmissionResponseImporter.new(current_user, uploaded_file.original_filename)
-    importer.import(uploaded_file.path)
+
+    SubmissionResponseImportJob.perform_later(
+      user_id: current_user.id,
+      file_name: uploaded_file.original_filename,
+      file_contents: uploaded_file.read,
+    )
+
+    flash[:notice] = 'Your file has been uploaded and is being imported'
     redirect_to landing_page_admin_path
   end
 end

--- a/app/jobs/submission_response_import_job.rb
+++ b/app/jobs/submission_response_import_job.rb
@@ -1,0 +1,10 @@
+class SubmissionResponseImportJob < ApplicationJob
+  queue_as :default
+
+  # FIXME: this accepts the whole file contents as an in-memory string, which won't scale well
+  def perform user_id:, file_name:, file_contents:
+    user = User.find user_id
+    importer = Importers::SubmissionResponseImporter.new user, file_name
+    importer.import_string file_contents
+  end
+end

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -109,7 +109,18 @@ class Importers::BaseImporter
     records_report("initial")
 
     rows = CSV.read(path, headers: true)
+    import_rows(rows)
+  end
 
+  def import_string(string)
+    Rails.logger.info("START IMPORT------------#{Time.now}")
+    records_report("initial")
+
+    rows = CSV.parse(string, headers: true)
+    import_rows(rows)
+  end
+
+  def import_rows(rows)
     process_headers_as_data(rows)
 
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
**Important**: this implementation has two major limitations:
1. Uses the `:async` queue backend which is in-memory only and isn't usually recommended for production. For now, to support imports only which typically happen before an installation is live, it might suffice. It does have the distinct advantage of not needing any additional infrastructure
2. Passes the _whole_ uploaded file contents into the background job as a string. This will obviously not scale and we'll have to monitor how feasible this is.

Resolves #585.