### PR TITLE
Only show visible subcategories on forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Bugfixes
+* Only show visible subcategories for any visible category #594
+
 ## [0.2.4] - 2020-07-23
 ### Bugfixes
 * Make login logo get populated from current_organization (last is_instance_owner) #581

--- a/app/blueprints/category_blueprint.rb
+++ b/app/blueprints/category_blueprint.rb
@@ -8,6 +8,6 @@ class CategoryBlueprint < Blueprinter::Base
     # Note we are _not_ propogating the :with_subcategories view to children.
     # This is intentional because we don't currently have multiply
     # nested categories so we don't need to dig any deeper.
-    association :categories, name: :subcategories, blueprint: CategoryBlueprint
+    association :visible_subcategories, name: :subcategories, blueprint: CategoryBlueprint
   end
 end

--- a/app/blueprints/configuration_blueprint.rb
+++ b/app/blueprints/configuration_blueprint.rb
@@ -1,6 +1,6 @@
 class ConfigurationBlueprint < Blueprinter::Base
   association :categories, blueprint: CategoryBlueprint, view: :with_subcategories do
-    Category.visible.roots.includes(:categories)
+    Category.visible.roots.includes(:visible_subcategories)
   end
 
   association :contact_methods, blueprint: ContactMethodBlueprint do

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,6 +10,12 @@ class Category < ApplicationRecord
     inverse_of: :parent
   )
 
+  has_many(:visible_subcategories, -> { visible.order(:display_order, :name) },
+           class_name: "Category",
+           foreign_key: :parent_id,
+           inverse_of: :parent
+  )
+
   validates :name, presence: true
 
   scope :visible, -> { where(display_to_public: true) }


### PR DESCRIPTION
- All subcategories for any visible Category were displaying, but the visible scope needs to be applied to subcategories as well