### PR TITLE
Handle current_organization errors in tests

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -22,6 +22,6 @@ class PublicPagesController < PublicController
     @landing_page_text_what = HtmlSanitizer.new(@system_setting.landing_page_text_what).sanitize_for_vue
     @landing_page_text_who = HtmlSanitizer.new(@system_setting.landing_page_text_who).sanitize_for_vue
     @landing_page_text_how = HtmlSanitizer.new(@system_setting.landing_page_text_how).sanitize_for_vue
-    @organization_name = Organization.current_organization.name
+    @organization_name = Organization.current_organization&.name
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,9 +8,11 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true
 
-  # TODO: rename to instance_owner?
-  scope :current_organization, -> { find_by(is_instance_owner: true) }
   scope :org_chart, -> { where(display_on_org_chart: true) }
+
+  def self.current_organization
+    where(is_instance_owner: true).last
+  end
 
   def primary_contact
     positions.find_by(is_primary: true)

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,7 @@
   document.addEventListener('DOMContentLoaded', () => {
     EntryPoints.navBar('#navBar', {
       loggedIn: <%= current_user.present? %>,
-      logoUrl: '<%= Organization.current_organization.logo_url %>'
+      logoUrl: '<%= Organization.current_organization&.logo_url %>'
     })
   })
 </script>

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "/listings", type: :request do
+  let(:organization) { create :organization, is_instance_owner: true }
   let(:valid_attributes) {{
     location_attributes: {zip: "12345"},
     tag_list: ["", "cash"],

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "/", type: :request do
+  let(:organization) { create :organization, is_instance_owner: true }
+
   it 'has landing_page_text_what populated from system_setting' do
     expected_what_text = Faker::Lorem.sentence
     new_system_setting = build(:system_setting, landing_page_text_what: expected_what_text)


### PR DESCRIPTION
- Change current_organization from a scope to a class method, since it's not returning a collection
- Add some let statements to tests
- Add some conditionals for when current_organization isn't present (in the wild, we *do* want to always have one)