### PR TITLE
Fix pending specs for SubmissionForm updating

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--no-profile

--- a/app/forms/submission_form.rb
+++ b/app/forms/submission_form.rb
@@ -37,16 +37,18 @@ class SubmissionForm < BaseForm
     end
 
     def build_submission
-      (id? ? Submission.find(id) : Submission.new).tap do |submission|
+      submission.tap do |submission|
         submission.attributes = submission_attributes
       end
     end
 
     def build_submission_responses
-      @submission_responses = responses_attributes.each_with_object([]) do |(custom_form_question_id, answer), obj|
-        response = SubmissionResponseForm.build custom_form_question_id: custom_form_question_id,
-                                                string_response: answer
-        obj << response
+      @submission_responses = responses_attributes.map do |(custom_form_question_id, answer)|
+        SubmissionResponseForm.build(
+          submission: submission,
+          custom_form_question_id: custom_form_question_id,
+          string_response: answer,
+        )
       end
     end
 
@@ -69,5 +71,9 @@ class SubmissionForm < BaseForm
       given_inputs
         .merge(service_area: service_area.id)
         .to_json
+    end
+
+    def submission
+      @submisson ||= Submission.find_or_new(id)
     end
 end

--- a/app/forms/submission_response_form.rb
+++ b/app/forms/submission_response_form.rb
@@ -1,4 +1,6 @@
 class SubmissionResponseForm < BaseForm
+  record :submission
+
   with_options default: nil do
     integer  :id
     integer  :custom_form_question_id
@@ -12,8 +14,11 @@ class SubmissionResponseForm < BaseForm
   end
 
   def execute
-    SubmissionResponse.find_or_new(id).tap do |submission_response|
-      submission_response.attributes = given_inputs
-    end
+    response = submission.submission_responses.find { |response|
+      response.custom_form_question_id == custom_form_question_id
+    } || SubmissionResponse.new
+
+    response.attributes = given_inputs
+    response
   end
 end

--- a/spec/forms/submission_form_spec.rb
+++ b/spec/forms/submission_form_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe SubmissionForm do
   let(:contact_method) { create :contact_method_email }
   let(:location_type)  { create :location_type }
   let(:service_area)   { create :service_area }
-  let(:question_1)   { create :custom_form_question }
-  let(:question_2)   { create :custom_form_question }
+  let(:questions)      { create_list :custom_form_question, 2 }
 
   describe 'creating a new submission' do
     let(:params) {{
@@ -30,8 +29,8 @@ RSpec.describe SubmissionForm do
         name: 'Harriet Tubman',
       },
       responses_attributes: {
-        question_1.id.to_s => "answer 1",
-        question_2.id.to_s => "answer 2"
+        questions.first.id.to_s  => "answer 1",
+        questions.second.id.to_s => "answer 2"
       },
     }}
 
@@ -127,11 +126,8 @@ RSpec.describe SubmissionForm do
       subject(:submission_responses) { submission.submission_responses }
 
       it 'builds SubmissionResponses' do
-        expect(submission_responses.first.string_response).to eq("answer 1")
-      end
-
-      it 'builds SubmissionResponses' do
         expect(submission_responses.length).to eq(2)
+        expect(submission_responses.first.string_response).to eq("answer 1")
       end
     end
 
@@ -196,7 +192,7 @@ RSpec.describe SubmissionForm do
     end
   end
 
-  pending 'updating an existing submission' do
+  describe 'updating an existing submission' do
     let(:existing_listing)  { create :offer, state: :unmatched, description: 'keep' }
     let(:existing_location) { create :location, city: 'Chicago', zip: '10101' }
     let(:existing_person)   { create :person, location: existing_location, name: 'old name', email: 'keep@me.org' }
@@ -241,7 +237,7 @@ RSpec.describe SubmissionForm do
     end
 
     it 'applies pending changes to submission and nested objects' do
-      expect(submission.submission_responses.first.string_response).to be_changed
+      expect(submission.submission_responses.first).to be_changed
       expect(submission.listings.first).to be_changed
       expect(submission.person.location).to be_changed
       expect(submission.person).to be_changed
@@ -249,7 +245,7 @@ RSpec.describe SubmissionForm do
     end
 
     it 'applies new values to submission and nested objects' do
-      expect(submission.submission_responses.first.state).to eq 'updated answer'
+      expect(submission.submission_responses.first.string_response).to eq 'updated answer'
       expect(submission.listings.first.state).to eq 'matched'
       expect(submission.person.location.city).to eq 'Shikaakwa'
       expect(submission.person.name).to eq 'new name'


### PR DESCRIPTION
Required looking up existing submission_responses by custom_form_question_id.