### PR TITLE
Logging and Configurable Postgres settings (docker-compose)

### DIFF
--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     volumes:
       - db:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: mat
-      POSTGRES_DB: mutualaidtompkins
+      POSTGRES_USER: ${POSTGRES_USER:-ma}
+      POSTGRES_DB: ${POSTGRES_DB:-mutualaid}
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     logging:
       driver: json-file
@@ -66,4 +66,3 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       POSTGRES_USER: mat
       POSTGRES_DB: mutualaidtompkins
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "200k"
+        max-file: "10"
   app:
     build:
       context: ../..
@@ -39,6 +44,11 @@ services:
       SECRET_KEY_BASE: "${SECRET_KEY_BASE}"
     volumes:
       - "public:/usr/src/app/public"
+    logging:
+      driver: json-file
+      options:
+        max-size: "200k"
+        max-file: "10"
   caddy:
     image: caddy
     volumes:
@@ -51,3 +61,9 @@ services:
     restart: always
     depends_on:
       - app
+    logging:
+      driver: json-file
+      options:
+        max-size: "200k"
+        max-file: "10"
+


### PR DESCRIPTION
Adds some default logging configuration for the prod docker-compose setup, and allows configuration (with fallbacks) for POSTGRES_USER and POSTGRES_DB (I accidentally opened that first PR with hard-coded Tompkins County values)